### PR TITLE
Fikset manglende elements i mappe i arkivstruktur.xsd

### DIFF
--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -166,8 +166,7 @@
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID"/>
             <xs:element name="mappeID" type="n5mdk:mappeID"/>
-<!--            TODO Skal denne være med? Fra arkivmelding.xsd mappe-->
-<!--            <xs:element name="ReferanseForeldermappe" type="n5mdk:systemID" minOccurs="0"/>-->
+            <xs:element name="ReferanseForeldermappe" type="n5mdk:systemID" minOccurs="0"/>
             <xs:element name="tittel" type="n5mdk:tittel"/>
             <xs:element name="offentligTittel" type="n5mdk:offentligTittel" minOccurs="0"/>
             <xs:element name="beskrivelse" type="n5mdk:beskrivelse" minOccurs="0"/>
@@ -186,9 +185,8 @@
             <xs:element name="kassasjon" type="kassasjon" minOccurs="0"/>
             <xs:element name="skjerming" type="skjerming" minOccurs="0"/>
             <xs:element name="gradering" type="gradering" minOccurs="0"/>
-<!--            TODO Skal denne være med? Fra arkivmelding.xsd mappe-->
-<!--            <xs:element name="klassifikasjon" type="klassifikasjon" minOccurs="0" maxOccurs="unbounded"/>--> 
-            <!-- Tillater mapper uten forekomster av (under)mappe og registrering -->
+            <xs:element name="klassifikasjon" type="klassifikasjon" minOccurs="0" maxOccurs="unbounded"/>- 
+            <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0"/>
             <xs:choice>
                 <xs:element name="mappe" type="mappe" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="registrering" type="registrering" minOccurs="0" maxOccurs="unbounded"/>


### PR DESCRIPTION
Nå skal mappe i arkivstruktur ha de samme elements som den i arkivmelding.
ReferanseEksternNoekkel manglet f.eks.