### PR TITLE
Endret referanseForelderMappe til ny complextype med choice #77

### DIFF
--- a/Schema/V1/arkivmelding.xsd
+++ b/Schema/V1/arkivmelding.xsd
@@ -30,7 +30,7 @@
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
             <xs:element name="mappeID" type="n5mdk:mappeID" minOccurs="0"/>
-            <xs:element name="ReferanseForeldermappe" type="n5mdk:systemID" minOccurs="0"/>
+            <xs:element name="referanseForeldermappe" type="referanseForelderMappe" minOccurs="0"/>
             <xs:element name="tittel" type="n5mdk:tittel"/>
             <xs:element name="offentligTittel" type="n5mdk:offentligTittel" minOccurs="0"/>
             <xs:element name="beskrivelse" type="n5mdk:beskrivelse" minOccurs="0"/>
@@ -131,7 +131,7 @@
             <xs:element name="arkivertAv" type="n5mdk:arkivertAv" minOccurs="0"/>
             <!-- Dersom en registrering kommer alene må den kunne plasseres i en mappe eller arkivdel-->
             <xs:choice minOccurs="0">
-                <xs:element name="referanseForelderMappe" type="n5mdk:systemID"/>
+                <xs:element name="referanseForelderMappe" type="referanseForelderMappe"/>
                 <xs:element name="arkivdel" type="n5mdk:kode"/>
             </xs:choice>
             <xs:element name="part" type="part" minOccurs="0" maxOccurs="unbounded"/>
@@ -373,5 +373,20 @@
             <xs:pattern value="[A-Z]{2}"/>
         </xs:restriction>
     </xs:simpleType>
+
+    <xs:complexType name="referanseForelderMappe">
+        <xs:choice>
+            <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
+            <xs:element name="referanseEksternNoekkel" type="arkivstruktur:eksternNoekkel" minOccurs="0"/>
+            <xs:element name="saksnummer" type="saksnummer" minOccurs="0"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="saksnummer">
+        <xs:sequence>
+            <xs:element name="saksaar" type="n5mdk:saksaar" />
+            <xs:element name="sakssekvensnummer" type="n5mdk:sakssekvensnummer" />
+        </xs:sequence>
+    </xs:complexType>
 
 </xs:schema>


### PR DESCRIPTION
Endret arkivmelding.xsd i henhold til [issue #77](https://github.com/ks-no/fiks-arkiv/issues/77)
I issue refereres det til **saksnummer** som en type som består av **saksaar** og **saksekvensnummer**.
Denne eksisterte ikke i noen skjema så vidt jeg kan se, så jeg la den til i `arkivmelding.xsd` 
Men vil det være naturlig å bruke denne nye typen også andre steder? 