### PR TITLE
Egen inkluder for journalpostHent og mappeHent

### DIFF
--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -559,25 +559,6 @@
         </xs:sequence>
     </xs:complexType>
 
-    <xs:simpleType name="inkluder">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="mappe"/>
-            <xs:enumeration value="registrering"/>
-            <xs:enumeration value="klasse"/>
-            <xs:enumeration value="noekkelord"/>
-            <xs:enumeration value="kryssreferanse"/>
-            <xs:enumeration value="part"/>
-            <xs:enumeration value="merknad"/>
-            <xs:enumeration value="presedens"/>
-            <xs:enumeration value="moetedeltaker"/>
-            <xs:enumeration value="dokumentbeskrivelse"/>
-            <xs:enumeration value="korrespondansepart"/>
-            <xs:enumeration value="avskrivning"/>
-            <xs:enumeration value="dokumentflyt"/>
-            <xs:enumeration value="dokumentobjekt"/>
-        </xs:restriction>
-    </xs:simpleType>
-
     <xs:simpleType name="responsType">
         <xs:restriction base="xs:string">
             <xs:enumeration value="noekler"/>
@@ -593,4 +574,5 @@
             <xs:element name="poststed" type="n5mdk:poststed" />
         </xs:sequence>
     </xs:complexType>
+
 </xs:schema>

--- a/Schema/V1/journalpostHent.xsd
+++ b/Schema/V1/journalpostHent.xsd
@@ -24,9 +24,21 @@
 			 Klarer vi å beskrive det at man trenger bare 1 av alternativene? -->
 			<xs:element name="referanseEksternNoekkel" type="arkivstruktur:eksternNoekkel" minOccurs="0" maxOccurs="1"/>
 			<xs:element name="registreringsID" type="n5mdk:registreringsID" minOccurs="0"/>
-			<xs:element name="inkluder" type="arkivstruktur:inkluder" minOccurs="0"/>
+			<xs:element name="inkluder" type="inkluder" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
 
+	<xs:simpleType name="inkluder">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="merknad"/>
+			<xs:enumeration value="noekkelord"/>
+			<xs:enumeration value="kryssreferanse"/>
+			<xs:enumeration value="dokumentbeskrivelse"/>
+			<xs:enumeration value="korrespondansepart"/>
+			<xs:enumeration value="avskrivning"/>
+			<xs:enumeration value="dokumentflyt"/>
+			<xs:enumeration value="dokumentobjekt"/>
+		</xs:restriction>
+	</xs:simpleType>
 
 </xs:schema>

--- a/Schema/V1/mappeHent.xsd
+++ b/Schema/V1/mappeHent.xsd
@@ -22,9 +22,20 @@
             <xs:element name="referanseEksternNoekkel" type="arkivstruktur:eksternNoekkel" minOccurs="0"/>
             <!-- Er det enten referanseEksternNoekkel eller mappeID som kan identifisere en unik mappe?
 			Klarer vi å beskrive det at man trenger bare 1 av 2? -->
-            <xs:element name="inkluder" type="arkivstruktur:inkluder" minOccurs="0"/>
+            <xs:element name="inkluder" type="inkluder" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 
+    <xs:simpleType name="inkluder">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="merknad"/>
+            <xs:enumeration value="noekkelord"/>
+            <xs:enumeration value="kryssreferanse"/>
+            <xs:enumeration value="klasse"/>
+            <xs:enumeration value="part"/>
+            <xs:enumeration value="presedens"/>
+            <xs:enumeration value="moetedeltaker"/>
+        </xs:restriction>
+    </xs:simpleType>
 
 </xs:schema>


### PR DESCRIPTION
Inkluder simpleType kunne ikke være lik for journalpostHent og mappeHent. Issue #83

Slettet inkluder i arkivstruktur.xsd da den ikke lenger er i bruk og laget egne for journalpostHent.xsd og mappeHent.xsd
[Se issue 83](https://github.com/ks-no/fiks-arkiv/issues/83)