### PR TITLE
Rydding i arkivstrukturMinimum og arkivstrukturNoekler

### DIFF
--- a/Schema/V1/arkivmelding.xsd
+++ b/Schema/V1/arkivmelding.xsd
@@ -7,8 +7,6 @@
            elementFormDefault="qualified">
     <xs:import namespace="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
                schemaLocation="./metadatakatalog.xsd"/>
-    <xs:import namespace="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
-               schemaLocation="./arkivstruktur.xsd"/>
 
     <xs:element name="arkivmelding" type="arkivmelding"/>
 
@@ -291,13 +289,13 @@
     </xs:complexType>
 
     <xs:complexType name="avskrivning">
-        <xs:complexContent>
-            <xs:extension base="arkivstruktur:avskrivning">
-                <xs:sequence>
-                    <xs:element name="referanseAvskriverJournalpost" type="n5mdk:referanseAvskriverJournalpost" minOccurs="0"/>
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
+        <xs:sequence>
+            <xs:element name="avskrivningsdato" type="n5mdk:avskrivningsdato"/>
+            <xs:element name="avskrevetAv" type="n5mdk:avskrevetAv"/>
+            <xs:element name="avskrivningsmaate" type="n5mdk:avskrivningsmaate"/>
+            <xs:element name="referanseAvskrivesAvJournalpost" type="n5mdk:referanseAvskrivesAvJournalpost" minOccurs="0"/>
+            <xs:element name="referanseAvskriverJournalpost" type="n5mdk:referanseAvskriverJournalpost" minOccurs="0"/>
+        </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="hendelseslogg">

--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -208,8 +208,6 @@
                     <xs:element name="saksstatus" type="n5mdk:saksstatus"/>
                     <xs:element name="utlaantDato" type="n5mdk:utlaantDato" minOccurs="0"/>
                     <xs:element name="utlaantTil" type="n5mdk:utlaantTil" minOccurs="0"/>
-                    <xs:element name="referanseSekundaerKlassifikasjon" type="n5mdk:referanseSekundaerKlassifikasjon"
-                                minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="presedens" type="presedens" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:sequence>
             </xs:extension>
@@ -222,7 +220,6 @@
             <xs:element name="noekkel" type="n5mdk:noekkel"/>
         </xs:sequence>
     </xs:complexType>
-
 
     <xs:complexType name="klassifikasjon">
         <xs:sequence>

--- a/Schema/V1/arkivstrukturMinimum.xsd
+++ b/Schema/V1/arkivstrukturMinimum.xsd
@@ -19,12 +19,16 @@
             <xs:element name="systemID" type="n5mdk:systemID"/>
             <xs:element name="klassifikasjonstype" type="n5mdk:klassifikasjonstype" minOccurs="0"/>
             <xs:element name="tittel" type="n5mdk:tittel"/>
-            <xs:element name="beskrivelse" type="n5mdk:beskrivelse" minOccurs="0"/>
-            <xs:element name="opprettetDato" type="n5mdk:opprettetDato"/>
-            <xs:element name="opprettetAv" type="n5mdk:opprettetAv"/>
-            <xs:element name="avsluttetDato" type="n5mdk:avsluttetDato" minOccurs="0"/>
-            <xs:element name="avsluttetAv" type="n5mdk:avsluttetAv" minOccurs="0"/>
-            <xs:element name="klasse" type="klasseMinimum" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="klassifikasjon">
+        <xs:sequence>
+            <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
+            <xs:element name="klassifikasjonssystem" type="klassifikasjonssystemMinimum"/>
+            <xs:element name="klasseID" type="n5mdk:klasseID"/>
+            <xs:element name="tittel" type="n5mdk:tittel" minOccurs="0"/>
+            <xs:element name="skjermetObjekt" type="n5mdk:skjermetObjekt" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -33,22 +37,9 @@
             <xs:element name="systemID" type="n5mdk:systemID"/>
             <xs:element name="klasseID" type="n5mdk:klasseID"/>
             <xs:element name="tittel" type="n5mdk:tittel"/>
-            <xs:element name="beskrivelse" type="n5mdk:beskrivelse" minOccurs="0"/>
-            <xs:element name="noekkelord" type="n5mdk:noekkelord" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="opprettetDato" type="n5mdk:opprettetDato"/>
-            <xs:element name="opprettetAv" type="n5mdk:opprettetAv"/>
-            <xs:element name="avsluttetDato" type="n5mdk:avsluttetDato" minOccurs="0"/>
-            <xs:element name="avsluttetAv" type="n5mdk:avsluttetAv" minOccurs="0"/>
-            <xs:element name="kryssreferanse" type="kryssreferanseMinimum" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="kassasjon" type="kassasjonMinimum" minOccurs="0"/>
             <xs:element name="skjerming" type="skjermingMinimum" minOccurs="0"/>
             <xs:element name="gradering" type="graderingMinimum" minOccurs="0"/>
-            <!-- Tillater klasser uten forekomster av (under)klasse, mappe og registering -->
-            <xs:choice>
-                <xs:element name="klasse" type="klasseMinimum" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element name="mappe" type="mappeMinimum" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element name="registrering" type="registreringMinimum" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:choice>
+            <xs:element name="klassifikasjonssystem" type="klassifikasjonssystemMinimum" />
         </xs:sequence>
     </xs:complexType>
 
@@ -58,18 +49,10 @@
             <xs:element name="mappeID" type="n5mdk:mappeID"/>
             <xs:element name="tittel" type="n5mdk:tittel"/>
             <xs:element name="offentligTittel" type="n5mdk:offentligTittel" minOccurs="0"/>
-            <xs:element name="beskrivelse" type="n5mdk:beskrivelse" minOccurs="0"/>
-            <xs:element name="dokumentmedium" type="n5mdk:dokumentmedium" minOccurs="0"/>
-            <xs:element name="oppbevaringssted" type="n5mdk:oppbevaringssted" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="opprettetDato" type="n5mdk:opprettetDato"/>
-            <xs:element name="opprettetAv" type="n5mdk:opprettetAv"/>
-            <xs:element name="avsluttetDato" type="n5mdk:avsluttetDato"/>
-            <xs:element name="avsluttetAv" type="n5mdk:avsluttetAv"/>
-            <xs:element name="arkivdel" type="n5mdk:kode" minOccurs="0"/>
-            <xs:element name="kassasjon" type="kassasjonMinimum" minOccurs="0"/>
             <xs:element name="skjerming" type="skjermingMinimum" minOccurs="0"/>
             <xs:element name="gradering" type="graderingMinimum" minOccurs="0"/>
-            <!-- Tillater mapper uten forekomster av (under)mappe og registrering -->
+            <xs:element name="klassifikasjon" type="klassifikasjon" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0"/> <!-- Kanskje? -->
             <xs:choice>
                 <xs:element name="mappe" type="mappeMinimum" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="registrering" type="registreringMinimum" minOccurs="0" maxOccurs="unbounded"/>
@@ -86,13 +69,7 @@
                     <xs:element name="saksdato" type="n5mdk:saksdato"/>
                     <xs:element name="administrativEnhet" type="n5mdk:administrativEnhet"/>
                     <xs:element name="saksansvarlig" type="n5mdk:saksansvarlig"/>
-                    <xs:element name="journalenhet" type="n5mdk:journalenhet" minOccurs="0"/>
                     <xs:element name="saksstatus" type="n5mdk:saksstatus"/>
-                    <xs:element name="utlaantDato" type="n5mdk:utlaantDato" minOccurs="0"/>
-                    <xs:element name="utlaantTil" type="n5mdk:utlaantTil" minOccurs="0"/>
-                    <xs:element name="referanseSekundaerKlassifikasjon" type="n5mdk:referanseSekundaerKlassifikasjon"
-                                minOccurs="0" maxOccurs="unbounded"/>
-                    <xs:element name="presedens" type="presedensMinimum" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
@@ -101,11 +78,6 @@
     <xs:complexType name="registreringMinimum">
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID"/>
-            <xs:element name="opprettetDato" type="n5mdk:opprettetDato"/>
-            <xs:element name="opprettetAv" type="n5mdk:opprettetAv"/>
-            <xs:element name="arkivertDato" type="n5mdk:arkivertDato"/>
-            <xs:element name="arkivertAv" type="n5mdk:arkivertAv"/>
-            <xs:element name="arkivdel" type="n5mdk:kode" minOccurs="0"/>
             <xs:element name="skjerming" type="skjermingMinimum" minOccurs="0"/>
             <xs:element name="gradering" type="graderingMinimum" minOccurs="0"/>
             <!-- Tillater registreringer uten forekomster av dokumentbeskrivelse -->
@@ -114,11 +86,6 @@
             <xs:element name="registreringsID" type="n5mdk:registreringsID" minOccurs="0"/>
             <xs:element name="tittel" type="n5mdk:tittel"/>
             <xs:element name="offentligTittel" type="n5mdk:offentligTittel" minOccurs="0"/>
-            <xs:element name="beskrivelse" type="n5mdk:beskrivelse" minOccurs="0"/>
-            <xs:element name="noekkelord" type="n5mdk:noekkelord" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="forfatter" type="n5mdk:forfatter" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="dokumentmedium" type="n5mdk:dokumentmedium" minOccurs="0"/>
-            <xs:element name="oppbevaringssted" type="n5mdk:oppbevaringssted" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="korrespondansepart" type="korrespondansepartMinimum" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
@@ -134,12 +101,6 @@
                     <xs:element name="journalstatus" type="n5mdk:journalstatus"/>
                     <xs:element name="journaldato" type="n5mdk:journaldato"/>
                     <xs:element name="dokumentetsDato" type="n5mdk:dokumentetsDato" minOccurs="0"/>
-                    <xs:element name="mottattDato" type="n5mdk:mottattDato" minOccurs="0"/>
-                    <xs:element name="sendtDato" type="n5mdk:sendtDato" minOccurs="0"/>
-                    <xs:element name="forfallsdato" type="n5mdk:forfallsdato" minOccurs="0"/>
-                    <xs:element name="offentlighetsvurdertDato" type="n5mdk:offentlighetsvurdertDato" minOccurs="0"/>
-                    <xs:element name="antallVedlegg" type="n5mdk:antallVedlegg" minOccurs="0"/>
-                    <xs:element name="avskrivning" type="avskrivningMinimum" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
@@ -149,25 +110,6 @@
         <xs:sequence>
             <xs:element name="korrespondanseparttype" type="n5mdk:korrespondanseparttype"/>
             <xs:element name="korrespondansepartNavn" type="n5mdk:korrespondansepartNavn"/>
-            <xs:element name="postadresse" type="n5mdk:postadresse" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="postnummer" type="n5mdk:postnummer" minOccurs="0"/>
-            <xs:element name="poststed" type="n5mdk:poststed" minOccurs="0"/>
-            <xs:element name="land" type="n5mdk:land" minOccurs="0"/>
-            <xs:element name="epostadresse" type="n5mdk:epostadresse" minOccurs="0"/>
-            <xs:element name="telefonnummer" type="n5mdk:telefonnummer" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="kontaktperson" type="n5mdk:kontaktperson" minOccurs="0"/>
-            <xs:element name="administrativEnhet" type="n5mdk:administrativEnhet" minOccurs="0"/>
-            <xs:element name="saksbehandler" type="n5mdk:saksbehandler" minOccurs="0"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="avskrivningMinimum">
-        <xs:sequence>
-            <xs:element name="avskrivningsdato" type="n5mdk:avskrivningsdato"/>
-            <xs:element name="avskrevetAv" type="n5mdk:avskrevetAv"/>
-            <xs:element name="avskrivningsmaate" type="n5mdk:avskrivningsmaate"/>
-            <xs:element name="referanseAvskrivesAvJournalpost" type="n5mdk:referanseAvskrivesAvJournalpost"
-                        minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -177,21 +119,8 @@
             <xs:element name="dokumenttype" type="n5mdk:dokumenttype"/>
             <xs:element name="dokumentstatus" type="n5mdk:dokumentstatus"/>
             <xs:element name="tittel" type="n5mdk:tittel"/>
-            <xs:element name="beskrivelse" type="n5mdk:beskrivelse" minOccurs="0"/>
-            <xs:element name="forfatter" type="n5mdk:forfatter" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="opprettetDato" type="n5mdk:opprettetDato"/>
-            <xs:element name="opprettetAv" type="n5mdk:opprettetAv"/>
-            <xs:element name="dokumentmedium" type="n5mdk:dokumentmedium" minOccurs="0"/>
-            <xs:element name="oppbevaringssted" type="n5mdk:oppbevaringssted" minOccurs="0"/>
-            <xs:element name="arkivdel" type="n5mdk:kode" minOccurs="0"/>
-            <xs:element name="tilknyttetRegistreringSom" type="n5mdk:tilknyttetRegistreringSom"/>
-            <xs:element name="dokumentnummer" type="n5mdk:dokumentnummer"/>
-            <xs:element name="tilknyttetDato" type="n5mdk:tilknyttetDato"/>
-            <xs:element name="tilknyttetAv" type="n5mdk:tilknyttetAv"/>
-            <xs:element name="sletting" type="slettingMinimum" minOccurs="0"/>
             <xs:element name="skjerming" type="skjermingMinimum" minOccurs="0"/>
             <xs:element name="gradering" type="graderingMinimum" minOccurs="0"/>
-            <xs:element name="elektroniskSignatur" type="elektroniskSignaturMinimum" minOccurs="0"/>
             <xs:element name="dokumentobjekt" type="dokumentobjektMinimum" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
@@ -203,59 +132,8 @@
             <xs:element name="variantformat" type="n5mdk:variantformat"/>
             <xs:element name="format" type="n5mdk:format"/>
             <xs:element name="formatDetaljer" type="n5mdk:formatDetaljer" minOccurs="0"/>
-            <xs:element name="opprettetDato" type="n5mdk:opprettetDato"/>
-            <xs:element name="opprettetAv" type="n5mdk:opprettetAv"/>
             <xs:element name="referanseDokumentfil" type="n5mdk:referanseDokumentfil"/>
-            <xs:element name="sjekksum" type="n5mdk:sjekksum"/>
-            <xs:element name="sjekksumAlgoritme" type="n5mdk:sjekksumAlgoritme"/>
             <xs:element name="filstoerrelse" type="n5mdk:filstoerrelse"/>
-            <xs:element name="elektroniskSignatur" type="elektroniskSignaturMinimum" minOccurs="0"/>
-            <xs:element name="konvertering" type="konverteringMinimum" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="konverteringMinimum">
-        <xs:sequence>
-            <xs:element name="konvertertDato" type="n5mdk:konvertertDato"/>
-            <xs:element name="konvertertAv" type="n5mdk:konvertertAv"/>
-            <xs:element name="konvertertFraFormat" type="n5mdk:konvertertFraFormat"/>
-            <xs:element name="konvertertTilFormat" type="n5mdk:konvertertTilFormat"/>
-            <xs:element name="konverteringsverktoey" type="n5mdk:konverteringsverktoey" minOccurs="0"/>
-            <xs:element name="konverteringskommentar" type="n5mdk:konverteringskommentar" minOccurs="0"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="kryssreferanseMinimum">
-        <xs:sequence>
-            <xs:element name="referanseTilKlasse" type="n5mdk:referanseTilKlasse" minOccurs="0"/>
-            <xs:element name="referanseTilMappe" type="n5mdk:referanseTilMappe" minOccurs="0"/>
-            <xs:element name="referanseTilRegistrering" type="n5mdk:referanseTilRegistrering" minOccurs="0"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="merknadMinimum">
-        <xs:sequence>
-            <xs:element name="merknadstekst" type="n5mdk:merknadstekst"/>
-            <xs:element name="merknadstype" type="n5mdk:merknadstype" minOccurs="0"/>
-            <xs:element name="merknadsdato" type="n5mdk:merknadsdato"/>
-            <xs:element name="merknadRegistrertAv" type="n5mdk:merknadRegistrertAv"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="kassasjonMinimum">
-        <xs:sequence>
-            <xs:element name="kassasjonsvedtak" type="n5mdk:kassasjonsvedtak"/>
-            <xs:element name="kassasjonshjemmel" type="n5mdk:kassasjonshjemmel" minOccurs="0"/>
-            <xs:element name="bevaringstid" type="n5mdk:bevaringstid"/>
-            <xs:element name="kassasjonsdato" type="n5mdk:kassasjonsdato"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="slettingMinimum">
-        <xs:sequence>
-            <xs:element name="slettingstype" type="n5mdk:slettingstype"/>
-            <xs:element name="slettetDato" type="n5mdk:slettetDato"/>
-            <xs:element name="slettetAv" type="n5mdk:slettetAv"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -280,29 +158,10 @@
         </xs:sequence>
     </xs:complexType>
 
-    <xs:complexType name="presedensMinimum">
+    <xs:complexType name="eksternNoekkel">
         <xs:sequence>
-            <xs:element name="presedensDato" type="n5mdk:presedensDato"/>
-            <xs:element name="opprettetDato" type="n5mdk:opprettetDato"/>
-            <xs:element name="opprettetAv" type="n5mdk:opprettetAv"/>
-            <xs:element name="tittel" type="n5mdk:tittel"/>
-            <xs:element name="beskrivelse" type="n5mdk:beskrivelse" minOccurs="0"/>
-            <xs:element name="presedensHjemmel" type="n5mdk:presedensHjemmel" minOccurs="0"/>
-            <xs:element name="rettskildefaktor" type="n5mdk:rettskildefaktor"/>
-            <xs:element name="presedensGodkjentDato" type="n5mdk:presedensGodkjentDato" minOccurs="0"/>
-            <xs:element name="presedensGodkjentAv" type="n5mdk:presedensGodkjentAv" minOccurs="0"/>
-            <xs:element name="avsluttetDato" type="n5mdk:avsluttetDato" minOccurs="0"/>
-            <xs:element name="avsluttetAv" type="n5mdk:avsluttetAv" minOccurs="0"/>
-            <xs:element name="presedensStatus" type="n5mdk:presedensStatus" minOccurs="0"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="elektroniskSignaturMinimum">
-        <xs:sequence>
-            <xs:element name="elektroniskSignaturSikkerhetsnivaa" type="n5mdk:elektroniskSignaturSikkerhetsnivaa"/>
-            <xs:element name="elektroniskSignaturVerifisert" type="n5mdk:elektroniskSignaturVerifisert"/>
-            <xs:element name="verifisertDato" type="n5mdk:verifisertDato"/>
-            <xs:element name="verifisertAv" type="n5mdk:verifisertAv"/>
+            <xs:element name="fagsystem" type="n5mdk:fagsystem"/>
+            <xs:element name="noekkel" type="n5mdk:noekkel"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/Schema/V1/arkivstrukturNoekler.xsd
+++ b/Schema/V1/arkivstrukturNoekler.xsd
@@ -22,11 +22,6 @@
             <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
             <xs:element name="mappeID" type="n5mdk:mappeID" minOccurs="0"/>
             <xs:element minOccurs="0" name="ReferanseForeldermappe" type="n5mdk:systemID"/>
-            <xs:element name="opprettetDato" type="n5mdk:opprettetDato" minOccurs="0"/>
-            <xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
-            <xs:element name="avsluttetDato" type="n5mdk:avsluttetDato" minOccurs="0"/>
-            <xs:element name="avsluttetAv" type="n5mdk:avsluttetAv" minOccurs="0"/>
-            <xs:element name="part" type="partNoekler" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="referanseEksternNoekkel" type="arkivstruktur:eksternNoekkel" minOccurs="0"/>
             <xs:choice>
                 <xs:element name="mappe" type="mappeNoekler" minOccurs="0" maxOccurs="unbounded"/>
@@ -39,9 +34,7 @@
         <xs:complexContent>
             <xs:extension base="mappeNoekler">
                 <xs:sequence>
-                    <xs:element name="saksaar" type="n5mdk:saksaar" minOccurs="0"/>
-                    <xs:element name="sakssekvensnummer" type="n5mdk:sakssekvensnummer" minOccurs="0"/>
-                    <xs:element name="saksdato" type="n5mdk:saksdato" minOccurs="0"/>
+                    <xs:element name="saksnummer" type="saksnummer" minOccurs="0"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
@@ -56,18 +49,11 @@
     <xs:complexType name="registreringNoekler">
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
-            <xs:element name="opprettetDato" type="n5mdk:opprettetDato" minOccurs="0"/>
-            <xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
-            <xs:element name="arkivertDato" type="n5mdk:arkivertDato" minOccurs="0"/>
-            <xs:element name="arkivertAv" type="n5mdk:arkivertAv" minOccurs="0"/>
-            <!-- Dersom ren registrering kommer alene må den kunne plasseres i en mappe eller arkivdel-->
             <xs:choice minOccurs="0">
-                <xs:element name="referanseForelderMappe" type="n5mdk:systemID"/>
+                <xs:element name="referanseForelderMappe" type="referanseForelderMappe"/>
                 <xs:element name="arkivdel" type="n5mdk:kode"/>
             </xs:choice>
-            <xs:element name="dokumentbeskrivelse" type="dokumentbeskrivelseNoekler" minOccurs="0"
-                        maxOccurs="unbounded"/>
-            <xs:element name="registreringsID" type="n5mdk:registreringsID" minOccurs="0"/>
+            <xs:element name="dokumentbeskrivelse" type="dokumentbeskrivelseNoekler" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="referanseEksternNoekkel" type="arkivstruktur:eksternNoekkel"/>
         </xs:sequence>
     </xs:complexType>
@@ -81,14 +67,6 @@
                                 minOccurs="0"/>
                     <xs:element name="journalpostnummer" type="n5mdk:journalpostnummer"
                                 minOccurs="0"/>
-                    <xs:element name="journalposttype" type="n5mdk:journalposttype"/>
-                    <xs:element name="journalstatus" type="n5mdk:journalstatus"/>
-                    <xs:element name="journaldato" type="n5mdk:journaldato" minOccurs="0"/>
-                    <xs:element name="dokumentetsDato" type="n5mdk:dokumentetsDato" minOccurs="0"/>
-                    <xs:element name="mottattDato" type="n5mdk:mottattDato" minOccurs="0"/>
-                    <xs:element name="sendtDato" type="n5mdk:sendtDato" minOccurs="0"/>
-                    <xs:element name="forfallsdato" type="n5mdk:forfallsdato" minOccurs="0"/>
-                    <xs:element name="offentlighetsvurdertDato" type="n5mdk:offentlighetsvurdertDato" minOccurs="0"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
@@ -97,8 +75,21 @@
     <xs:complexType name="dokumentbeskrivelseNoekler">
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
-            <xs:element name="opprettetDato" type="n5mdk:opprettetDato" minOccurs="0"/>
-            <xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="referanseForelderMappe">
+        <xs:choice>
+            <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
+            <xs:element name="referanseEksternNoekkel" type="arkivstruktur:eksternNoekkel" minOccurs="0"/>
+            <xs:element name="saksnummer" type="saksnummer" minOccurs="0"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="saksnummer">
+        <xs:sequence>
+            <xs:element name="saksaar" type="n5mdk:saksaar" />
+            <xs:element name="sakssekvensnummer" type="n5mdk:sakssekvensnummer" />
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
Ryddet arkivstrukturMinimum og arkivstrukturNoekler

Følgende er gjort:
- Tatt bort felter som ikke skal være der i arkivstrukturMinimum og arkivstrukturNoekler.
- Endret referanseForelderMappe til ny complexType og lagt til saksnummer som ny complexType. 
- Tatt bort arkivstruktur referansen i arkivmelding.xsd