### PR TITLE
Endret til ks-no.github.io som host for alle våre skjema

### DIFF
--- a/Schema/V1/arkivmelding.xsd
+++ b/Schema/V1/arkivmelding.xsd
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.arkivverket.no/standarder/noark5/arkivmelding/v2"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmelding/v1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:n5mdk="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
-           xmlns:arkivstruktur="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
-           targetNamespace="http://www.arkivverket.no/standarder/noark5/arkivmelding/v2"
+           xmlns:n5mdk="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
+           xmlns:arkivstruktur="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
+           targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmelding/v1"
            elementFormDefault="qualified">
-    <xs:import namespace="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
                schemaLocation="./metadatakatalog.xsd"/>
-    <xs:import namespace="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
                schemaLocation="./arkivstruktur.xsd"/>
 
     <xs:element name="arkivmelding" type="arkivmelding"/>

--- a/Schema/V1/arkivmeldingKvittering.xsd
+++ b/Schema/V1/arkivmeldingKvittering.xsd
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.arkivverket.no/standarder/noark5/arkivmeldingkvittering/v2"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmeldingkvittering/v1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:n5mdk="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
-           xmlns:arkivstruktur="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
-           targetNamespace="http://www.arkivverket.no/standarder/noark5/arkivmeldingkvittering/v2"
+           xmlns:n5mdk="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
+           xmlns:arkivstruktur="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
+           targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmeldingkvittering/v1"
            elementFormDefault="qualified">
-    <xs:import namespace="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
                schemaLocation="./metadatakatalog.xsd"/>
-    <xs:import namespace="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
                schemaLocation="./arkivstruktur.xsd"/>
 
     <xs:element name="arkivmeldingKvittering" type="arkivmeldingKvittering"/>

--- a/Schema/V1/arkivmeldingOppdatering.xsd
+++ b/Schema/V1/arkivmeldingOppdatering.xsd
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.arkivverket.no/standarder/noark5/arkivmeldingoppdatering/v2"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmeldingoppdatering/v1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:n5mdk="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
-           xmlns:arkivstruktur="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
-           xmlns:arkivmelding="http://www.arkivverket.no/standarder/noark5/arkivmelding/v2"
-           targetNamespace="http://www.arkivverket.no/standarder/noark5/arkivmeldingoppdatering/v2"
+           xmlns:n5mdk="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
+           xmlns:arkivstruktur="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
+           xmlns:arkivmelding="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmelding/v1"
+           targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmeldingoppdatering/v1"
            elementFormDefault="qualified">
-    <xs:import namespace="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2" schemaLocation="./metadatakatalog.xsd"/>
-    <xs:import namespace="http://www.arkivverket.no/standarder/noark5/arkivmelding/v2" schemaLocation="./arkivmelding.xsd"/>
-    <xs:import namespace="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1" schemaLocation="./metadatakatalog.xsd"/>
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmelding/v1" schemaLocation="./arkivmelding.xsd"/>
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
                schemaLocation="./arkivstruktur.xsd"/>
     
     <xs:element name="arkivmeldingOppdatering" type="arkivmeldingOppdatering"/>

--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:n5mdk="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
-           targetNamespace="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
+           xmlns:n5mdk="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
+           targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
            elementFormDefault="qualified" attributeFormDefault="unqualified" version="5.0">
 
     <!-- 
@@ -57,7 +57,7 @@
         <xs:documentation xml:lang="no">Hovedskjema - skjema for arkivstruktur</xs:documentation>
     </xs:annotation>
 
-    <xs:import namespace="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
                schemaLocation="metadatakatalog.xsd"/>
 
     <!-- Rotelementet -->

--- a/Schema/V1/arkivstrukturMinimum.xsd
+++ b/Schema/V1/arkivstrukturMinimum.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="http://www.ks.no/standarder/fiks/arkiv/arkivstruktur/minimum/v1"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/minimum/v1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:n5mdk="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
-           targetNamespace="http://www.ks.no/standarder/fiks/arkiv/arkivstruktur/minimum/v1"
+           xmlns:n5mdk="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
+           targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/minimum/v1"
            elementFormDefault="qualified" attributeFormDefault="unqualified" version="5.0">
 
     <xs:annotation>
@@ -11,7 +11,7 @@
         <xs:documentation xml:lang="no">Hovedskjema - skjema for arkivstruktur for søkeresultat</xs:documentation>
     </xs:annotation>
 
-    <xs:import namespace="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
                schemaLocation="metadatakatalog.xsd"/>
 
     <xs:complexType name="klassifikasjonssystemMinimum">

--- a/Schema/V1/arkivstrukturNoekler.xsd
+++ b/Schema/V1/arkivstrukturNoekler.xsd
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="http://www.ks.no/standarder/fiks/arkiv/arkivstruktur/noekler/v1"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/noekler/v1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:n5mdk="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
-           xmlns:arkivstruktur="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
-           targetNamespace="http://www.ks.no/standarder/fiks/arkiv/arkivstruktur/noekler/v1"
+           xmlns:n5mdk="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
+           xmlns:arkivstruktur="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
+           targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/noekler/v1"
            elementFormDefault="qualified" attributeFormDefault="unqualified" version="5.0">
 
     <xs:annotation>
@@ -12,9 +12,9 @@
         <xs:documentation xml:lang="no">Hovedskjema - skjema for arkivstruktur for søkeresultat</xs:documentation>
     </xs:annotation>
 
-    <xs:import namespace="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
                schemaLocation="metadatakatalog.xsd"/>
-    <xs:import namespace="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
                schemaLocation="./arkivstruktur.xsd"/>
 
     <xs:complexType name="mappeNoekler">

--- a/Schema/V1/dokumentfilHent.xsd
+++ b/Schema/V1/dokumentfilHent.xsd
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.arkivverket.no/standarder/noark5/dokumentfil/hent/v2"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/dokumentfil/hent/v1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:n5mdk="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
-           targetNamespace="http://www.arkivverket.no/standarder/noark5/dokumentfil/hent/v2"
+           xmlns:n5mdk="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
+           targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/dokumentfil/hent/v1"
            elementFormDefault="qualified">
-    <xs:import namespace="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
                schemaLocation="./metadatakatalog.xsd"/>
 
     <xs:element name="dokumentfilHent" type="dokumentfilHent"/>

--- a/Schema/V1/feilmeldingBase.xsd
+++ b/Schema/V1/feilmeldingBase.xsd
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.arkivverket.no/standarder/noark5/feil/feilmelding/v2"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/feil/feilmelding/v1"
 			xmlns:xs="http://www.w3.org/2001/XMLSchema"
-			xmlns:n5mdk="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
-			targetNamespace="http://www.arkivverket.no/standarder/noark5/feil/feilmelding/v2"
+			xmlns:n5mdk="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
+			targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/feil/feilmelding/v1"
 			elementFormDefault="qualified">
 
-	<xs:import namespace="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
+	<xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
 			   schemaLocation="./metadatakatalog.xsd"/>
 
 	<xs:complexType name="feilmeldingBase">

--- a/Schema/V1/ikkefunnet.xsd
+++ b/Schema/V1/ikkefunnet.xsd
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.arkivverket.no/standarder/noark5/feil/ikkefunnet/v2"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/feil/ikkefunnet/v1"
 			xmlns:xs="http://www.w3.org/2001/XMLSchema"
-			xmlns:feilmelding="http://www.arkivverket.no/standarder/noark5/feil/feilmelding/v2"
-			targetNamespace="http://www.arkivverket.no/standarder/noark5/feil/ikkefunnet/v2"
+			xmlns:feilmelding="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/feil/feilmelding/v1"
+			targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/feil/ikkefunnet/v1"
 			elementFormDefault="qualified">
 
-	<xs:import namespace="http://www.arkivverket.no/standarder/noark5/feil/feilmelding/v2"
+	<xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/feil/feilmelding/v1"
 			   schemaLocation="./feilmeldingBase.xsd"/>
 
 	<xs:element name="ikkefunnet" type="feilmelding:feilmeldingBase" />

--- a/Schema/V1/journalpostHent.xsd
+++ b/Schema/V1/journalpostHent.xsd
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.arkivverket.no/standarder/noark5/journalpost/hent/v2"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/journalpost/hent/v1"
 			xmlns:xs="http://www.w3.org/2001/XMLSchema"
-			xmlns:n5mdk="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
-		  	xmlns:arkivstruktur="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
-			targetNamespace="http://www.arkivverket.no/standarder/noark5/journalpost/hent/v2"
+			xmlns:n5mdk="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
+		  	xmlns:arkivstruktur="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
+			targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/journalpost/hent/v1"
 			elementFormDefault="qualified">
-	<xs:import namespace="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
+	<xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
 		schemaLocation="./metadatakatalog.xsd"/>
-	<xs:import namespace="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
+	<xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
 			   schemaLocation="./arkivstruktur.xsd"/>
 
 	<xs:element name="journalpostHent" type="journalpostHent"/>

--- a/Schema/V1/journalpostHentResultat.xsd
+++ b/Schema/V1/journalpostHentResultat.xsd
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.arkivverket.no/standarder/noark5/journalpost/hent/resultat/v2"
+<xs:schema xmlns="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/journalpost/hent/resultat/v1"
 			xmlns:xs="http://www.w3.org/2001/XMLSchema"
-		   	xmlns:arkivstruktur="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
-			targetNamespace="http://www.arkivverket.no/standarder/noark5/journalpost/hent/resultat/v2"
+		   	xmlns:arkivstruktur="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
+			targetNamespace="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/journalpost/hent/resultat/v1"
 			elementFormDefault="qualified">
-	<xs:import namespace="http://www.arkivverket.no/standarder/noark5/arkivmelding/v2"
+	<xs:import namespace="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmelding/v1"
 	schemaLocation="./arkivmelding.xsd"/>
-	<xs:import namespace="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
+	<xs:import namespace="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
 			   schemaLocation="./arkivstruktur.xsd"/>
 
 	<xs:element name="journalpostHentResultat" type="journalpostHentResultat"/>

--- a/Schema/V1/journalpostHentResultat.xsd
+++ b/Schema/V1/journalpostHentResultat.xsd
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/journalpost/hent/resultat/v1"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/journalpost/hent/resultat/v1"
 			xmlns:xs="http://www.w3.org/2001/XMLSchema"
-		   	xmlns:arkivstruktur="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
-			targetNamespace="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/journalpost/hent/resultat/v1"
+		   	xmlns:arkivstruktur="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
+			targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/journalpost/hent/resultat/v1"
 			elementFormDefault="qualified">
-	<xs:import namespace="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmelding/v1"
+	<xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmelding/v1"
 	schemaLocation="./arkivmelding.xsd"/>
-	<xs:import namespace="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
+	<xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
 			   schemaLocation="./arkivstruktur.xsd"/>
 
 	<xs:element name="journalpostHentResultat" type="journalpostHentResultat"/>

--- a/Schema/V1/mappeHent.xsd
+++ b/Schema/V1/mappeHent.xsd
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 
-<xs:schema xmlns="http://www.arkivverket.no/standarder/noark5/mappe/hent/v2"
+<xs:schema xmlns="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/mappe/hent/v1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:n5mdk="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
-           xmlns:arkivstruktur="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
-           targetNamespace="http://www.arkivverket.no/standarder/noark5/mappe/hent/v2"
+           xmlns:n5mdk="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
+           xmlns:arkivstruktur="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
+           targetNamespace="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/mappe/hent/v1"
            elementFormDefault="qualified">
-    <xs:import namespace="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
+    <xs:import namespace="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
                schemaLocation="./metadatakatalog.xsd"/>
-    <xs:import namespace="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
+    <xs:import namespace="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
                schemaLocation="./arkivstruktur.xsd"/>
 
     <xs:element name="mappeHent" type="mappeHent"/>

--- a/Schema/V1/mappeHent.xsd
+++ b/Schema/V1/mappeHent.xsd
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 
-<xs:schema xmlns="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/mappe/hent/v1"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/mappe/hent/v1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:n5mdk="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
-           xmlns:arkivstruktur="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
-           targetNamespace="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/mappe/hent/v1"
+           xmlns:n5mdk="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
+           xmlns:arkivstruktur="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
+           targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/mappe/hent/v1"
            elementFormDefault="qualified">
-    <xs:import namespace="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
                schemaLocation="./metadatakatalog.xsd"/>
-    <xs:import namespace="hhttps://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
                schemaLocation="./arkivstruktur.xsd"/>
 
     <xs:element name="mappeHent" type="mappeHent"/>

--- a/Schema/V1/mappeHentResultat.xsd
+++ b/Schema/V1/mappeHentResultat.xsd
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.arkivverket.no/standarder/noark5/mappe/hent/resultat/v2"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/mappe/hent/resultat/v1"
 			xmlns:xs="http://www.w3.org/2001/XMLSchema"
-		   	xmlns:arkivstruktur="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
-			targetNamespace="http://www.arkivverket.no/standarder/noark5/mappe/hent/resultat/v2"
+		   	xmlns:arkivstruktur="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
+			targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/mappe/hent/resultat/v1"
 			elementFormDefault="qualified">
-	<xs:import namespace="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
+	<xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
 			   schemaLocation="./arkivstruktur.xsd"/>
 
 	<xs:element name="mappeHentResultat" type="mappeHentResultat"/>

--- a/Schema/V1/metadatakatalog.xsd
+++ b/Schema/V1/metadatakatalog.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-  targetNamespace="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
+  targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
   elementFormDefault="qualified" version="5.0">
 
   <!-- 

--- a/Schema/V1/serverfeil.xsd
+++ b/Schema/V1/serverfeil.xsd
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.arkivverket.no/standarder/noark5/feil/serverfeil/v2"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/feil/serverfeil/v1"
 			xmlns:xs="http://www.w3.org/2001/XMLSchema"
-			xmlns:feilmelding="http://www.arkivverket.no/standarder/noark5/feil/feilmelding/v2"
-			targetNamespace="http://www.arkivverket.no/standarder/noark5/feil/serverfeil/v2"
+			xmlns:feilmelding="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/feil/feilmelding/v1"
+			targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/feil/serverfeil/v1"
 			elementFormDefault="qualified">
 
-	<xs:import namespace="http://www.arkivverket.no/standarder/noark5/feil/feilmelding/v2"
+	<xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/feil/feilmelding/v1"
 			   schemaLocation="./feilmeldingBase.xsd"/>
 
 	<xs:element name="serverfeil" type="feilmelding:feilmeldingBase" />

--- a/Schema/V1/sok.xsd
+++ b/Schema/V1/sok.xsd
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.ks.no/standarder/fiks/arkiv/sok/v1"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/sok/v1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:arkivstruktur="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
-           targetNamespace="http://www.ks.no/standarder/fiks/arkiv/sok/v1" elementFormDefault="qualified">
+           xmlns:arkivstruktur="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
+           targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/sok/v1" elementFormDefault="qualified">
 
-    <xs:import namespace="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
                schemaLocation="./arkivstruktur.xsd"/>
     <xs:element name="sok" type="sok"/>
 

--- a/Schema/V1/sokeresultatMinimum.xsd
+++ b/Schema/V1/sokeresultatMinimum.xsd
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.ks.no/standarder/fiks/arkiv/sokeresultat/v1"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/sokeresultat/v1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://www.ks.no/standarder/fiks/arkiv/sokeresultat/v1"
-           xmlns:arkivstruktur="http://www.ks.no/standarder/fiks/arkiv/arkivstruktur/minimum/v1" elementFormDefault="qualified">
-    <xs:import namespace="http://www.ks.no/standarder/fiks/arkiv/arkivstruktur/minimum/v1" schemaLocation="arkivstrukturMinimum.xsd"/>
+           targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/sokeresultat/v1"
+           xmlns:arkivstruktur="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/minimum/v1" elementFormDefault="qualified">
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/minimum/v1" schemaLocation="arkivstrukturMinimum.xsd"/>
     
     <xs:element name="sokeresultatMinimum" type="sokeresultatMinimum"/>
     

--- a/Schema/V1/sokeresultatNoekler.xsd
+++ b/Schema/V1/sokeresultatNoekler.xsd
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.ks.no/standarder/fiks/arkiv/sokeresultat/v1"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/sokeresultat/v1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://www.ks.no/standarder/fiks/arkiv/sokeresultat/v1"
-           xmlns:arkivstruktur="http://www.ks.no/standarder/fiks/arkiv/arkivstruktur/noekler/v1" elementFormDefault="qualified">
-    <xs:import namespace="http://www.ks.no/standarder/fiks/arkiv/arkivstruktur/noekler/v1" schemaLocation="arkivstrukturNoekler.xsd"/>
+           targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/sokeresultat/v1"
+           xmlns:arkivstruktur="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/noekler/v1" elementFormDefault="qualified">
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/noekler/v1" schemaLocation="arkivstrukturNoekler.xsd"/>
     
     <xs:element name="sokeresultatNoekler" type="sokeresultatNoekler"/>
     

--- a/Schema/V1/sokeresultatUtvidet.xsd
+++ b/Schema/V1/sokeresultatUtvidet.xsd
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.ks.no/standarder/fiks/arkiv/sokeresultat/v1"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/sokeresultat/v1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://www.ks.no/standarder/fiks/arkiv/sokeresultat/v1"
-           xmlns:arkivstruktur="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
+           targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/sokeresultat/v1"
+           xmlns:arkivstruktur="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
            elementFormDefault="qualified">
-    <xs:import namespace="http://www.arkivverket.no/standarder/noark5/arkivstruktur"
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
                schemaLocation="arkivstruktur.xsd"/>
 
     <xs:element name="sokeresultat" type="sokeresultat"/>

--- a/Schema/V1/ugyldigforespoersel.xsd
+++ b/Schema/V1/ugyldigforespoersel.xsd
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns="http://www.arkivverket.no/standarder/noark5/feil/ugyldigforespoersel/v2"
+<xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/feil/ugyldigforespoersel/v1"
 			xmlns:xs="http://www.w3.org/2001/XMLSchema"
-			xmlns:feilmelding="http://www.arkivverket.no/standarder/noark5/feil/feilmelding/v2"
-			targetNamespace="http://www.arkivverket.no/standarder/noark5/feil/ugyldigforespoersel/v2"
+			xmlns:feilmelding="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/feil/feilmelding/v1"
+			targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/feil/ugyldigforespoersel/v1"
 			elementFormDefault="qualified">
 
-	<xs:import namespace="http://www.arkivverket.no/standarder/noark5/feil/feilmelding/v2"
+	<xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/feil/feilmelding/v1"
 			   schemaLocation="./feilmeldingBase.xsd"/>
 
 	<xs:element name="ugyldigforespoersel" type="feilmelding:feilmeldingBase" />


### PR DESCRIPTION
Endret til ks-no.github.io som host for alle våre skjema og definert det som versjon 1

Vi må ta eierskap over skjemaene og dermed peke til et ks.no domene hvor da namespace for skjema er. 
Dermed er det naturlig å sette det til versjon 1 for alle skjema. Hvis det senere skulle overføres til en annen organisasjon som f.eks. allerede har en arkivmelding kan det da bumpes til riktig versjon.