### PR TITLE
Forslag til endring mtp inkluder og respons typer. Issue #99

### DIFF
--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
@@ -247,13 +247,11 @@
     <xs:simpleType name="inkluderIMappe">
         <xs:restriction base="xs:string">
             <xs:enumeration value="mappe"/>
-            <xs:enumeration value="klasse"/>
+            <xs:enumeration value="registrering"/>
             <xs:enumeration value="noekkelord"/>
             <xs:enumeration value="kryssreferanse"/>
             <xs:enumeration value="part"/>
             <xs:enumeration value="merknad"/>
-            <xs:enumeration value="presedens"/>
-            <xs:enumeration value="moetedeltaker"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -261,14 +259,11 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="mappe"/>
             <xs:enumeration value="registrering"/>
-            <xs:enumeration value="klasse"/>
             <xs:enumeration value="noekkelord"/>
             <xs:enumeration value="kryssreferanse"/>
             <xs:enumeration value="part"/>
             <xs:enumeration value="merknad"/>
             <xs:enumeration value="presedens"/>
-            <xs:enumeration value="moetedeltaker"/>
-            <xs:enumeration value="dokumentbeskrivelse"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -279,8 +274,7 @@
             <xs:enumeration value="part"/>
             <xs:enumeration value="merknad"/>
             <xs:enumeration value="dokumentbeskrivelse"/>
-            <xs:enumeration value="dokumentflyt"/>
-            <xs:enumeration value="dokumentobjekt"/>
+            <xs:enumeration value="korrespondansepart"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -294,13 +288,11 @@
             <xs:enumeration value="korrespondansepart"/>
             <xs:enumeration value="avskrivning"/>
             <xs:enumeration value="dokumentflyt"/>
-            <xs:enumeration value="dokumentobjekt"/>
         </xs:restriction>
     </xs:simpleType>
 
     <xs:simpleType name="inkluderIDokumentbeskrivelse">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="dokumentflyt"/>
             <xs:enumeration value="dokumentobjekt"/>
         </xs:restriction>
     </xs:simpleType>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
@@ -244,29 +244,29 @@
         </xs:complexContent>
     </xs:complexType>
 
-    <xs:simpleType name="inkluder">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="mappe"/>
-            <xs:enumeration value="registrering"/>
-            <xs:enumeration value="klasse"/>
-            <xs:enumeration value="noekkelord"/>
-            <xs:enumeration value="kryssreferanse"/>
-            <xs:enumeration value="part"/>
-            <xs:enumeration value="merknad"/>
-            <xs:enumeration value="presedens"/>
-            <xs:enumeration value="moetedeltaker"/>
-            <xs:enumeration value="dokumentbeskrivelse"/>
-            <xs:enumeration value="korrespondansepart"/>
-            <xs:enumeration value="avskrivning"/>
-            <xs:enumeration value="dokumentflyt"/>
-            <xs:enumeration value="dokumentobjekt"/>
-        </xs:restriction>
-    </xs:simpleType>
+<!--    <xs:simpleType name="inkluder">-->
+<!--        <xs:restriction base="xs:string">-->
+<!--            <xs:enumeration value="mappe"/>-->
+<!--            <xs:enumeration value="registrering"/>-->
+<!--            <xs:enumeration value="klasse"/>-->
+<!--            <xs:enumeration value="noekkelord"/>-->
+<!--            <xs:enumeration value="kryssreferanse"/>-->
+<!--            <xs:enumeration value="part"/>-->
+<!--            <xs:enumeration value="merknad"/>-->
+<!--            <xs:enumeration value="presedens"/>-->
+<!--            <xs:enumeration value="moetedeltaker"/>-->
+<!--            <xs:enumeration value="dokumentbeskrivelse"/>-->
+<!--            <xs:enumeration value="korrespondansepart"/>-->
+<!--            <xs:enumeration value="avskrivning"/>-->
+<!--            <xs:enumeration value="dokumentflyt"/>-->
+<!--            <xs:enumeration value="dokumentobjekt"/>-->
+<!--        </xs:restriction>-->
+<!--    </xs:simpleType>-->
 
     <xs:simpleType name="inkluderIMappe">
         <xs:restriction base="xs:string">
             <xs:enumeration value="mappe"/>
-            <xs:enumeration value="registrering"/>
+<!--            <xs:enumeration value="registrering"/>-->
             <xs:enumeration value="klasse"/>
             <xs:enumeration value="noekkelord"/>
             <xs:enumeration value="kryssreferanse"/>
@@ -294,25 +294,25 @@
             <xs:enumeration value="presedens"/>
             <xs:enumeration value="moetedeltaker"/>
             <xs:enumeration value="dokumentbeskrivelse"/>
-            <xs:enumeration value="korrespondansepart"/>
-            <xs:enumeration value="avskrivning"/>
-            <xs:enumeration value="dokumentflyt"/>
-            <xs:enumeration value="dokumentobjekt"/>
+<!--            <xs:enumeration value="korrespondansepart"/>-->
+<!--            <xs:enumeration value="avskrivning"/>-->
+<!--            <xs:enumeration value="dokumentflyt"/>-->
+<!--            <xs:enumeration value="dokumentobjekt"/>-->
         </xs:restriction>
     </xs:simpleType>
 
     <xs:simpleType name="inkluderIRegistrering">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="klasse"/>
+<!--            <xs:enumeration value="klasse"/>-->
             <xs:enumeration value="noekkelord"/>
             <xs:enumeration value="kryssreferanse"/>
             <xs:enumeration value="part"/>
             <xs:enumeration value="merknad"/>
-            <xs:enumeration value="presedens"/>
-            <xs:enumeration value="moetedeltaker"/>
+<!--            <xs:enumeration value="presedens"/>-->
+<!--            <xs:enumeration value="moetedeltaker"/>-->
             <xs:enumeration value="dokumentbeskrivelse"/>
-            <xs:enumeration value="korrespondansepart"/>
-            <xs:enumeration value="avskrivning"/>
+<!--            <xs:enumeration value="korrespondansepart"/>-->
+<!--            <xs:enumeration value="avskrivning"/>-->
             <xs:enumeration value="dokumentflyt"/>
             <xs:enumeration value="dokumentobjekt"/>
         </xs:restriction>
@@ -320,13 +320,13 @@
 
     <xs:simpleType name="inkluderIJournalpost">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="klasse"/>
+<!--            <xs:enumeration value="klasse"/>-->
             <xs:enumeration value="noekkelord"/>
             <xs:enumeration value="kryssreferanse"/>
             <xs:enumeration value="part"/>
             <xs:enumeration value="merknad"/>
-            <xs:enumeration value="presedens"/>
-            <xs:enumeration value="moetedeltaker"/>
+<!--            <xs:enumeration value="presedens"/>-->
+<!--            <xs:enumeration value="moetedeltaker"/>-->
             <xs:enumeration value="dokumentbeskrivelse"/>
             <xs:enumeration value="korrespondansepart"/>
             <xs:enumeration value="avskrivning"/>
@@ -337,8 +337,8 @@
 
     <xs:simpleType name="inkluderIDokumentbeskrivelse">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="korrespondansepart"/>
-            <xs:enumeration value="avskrivning"/>
+<!--            <xs:enumeration value="korrespondansepart"/>-->
+<!--            <xs:enumeration value="avskrivning"/>-->
             <xs:enumeration value="dokumentflyt"/>
             <xs:enumeration value="dokumentobjekt"/>
         </xs:restriction>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
@@ -190,15 +190,59 @@
     </xs:simpleType>
 
     <!-- The respons is strict, meaning that the result should return the exact type set here. E.g. when set to mappe it should only return mappe in resultList -->
-    <xs:simpleType name="respons">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="mappe"/>
-            <xs:enumeration value="saksmappe"/>
-            <xs:enumeration value="registrering"/>
-            <xs:enumeration value="journalpost"/>
-            <xs:enumeration value="dokumentbeskrivelse"/>
-        </xs:restriction>
-    </xs:simpleType>
+    <xs:complexType name="respons">
+        
+    </xs:complexType>
+
+    <xs:complexType name="mappeRespons">
+        <xs:complexContent>
+            <xs:extension base="respons">
+                <xs:sequence>
+                    <xs:element name="inkluder" type="inkluderIMappe"/>
+                </xs:sequence> 
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="saksmappeRespons">
+        <xs:complexContent>
+            <xs:extension base="respons">
+                <xs:sequence>
+                    <xs:element name="inkluder" type="inkluderISaksmappe"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="registreringRespons">
+        <xs:complexContent>
+            <xs:extension base="respons">
+                <xs:sequence>
+                    <xs:element name="inkluder" type="inkluderIRegistrering"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="journalpostRespons">
+        <xs:complexContent>
+            <xs:extension base="respons">
+                <xs:sequence>
+                    <xs:element name="inkluder" type="inkluderIJournalpost"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="dokumentbeskrivelseRespons">
+        <xs:complexContent>
+            <xs:extension base="respons">
+                <xs:sequence>
+                    <xs:element name="inkluder" type="inkluderIDokumentbeskrivelse"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
 
     <xs:simpleType name="inkluder">
         <xs:restriction base="xs:string">
@@ -212,6 +256,87 @@
             <xs:enumeration value="presedens"/>
             <xs:enumeration value="moetedeltaker"/>
             <xs:enumeration value="dokumentbeskrivelse"/>
+            <xs:enumeration value="korrespondansepart"/>
+            <xs:enumeration value="avskrivning"/>
+            <xs:enumeration value="dokumentflyt"/>
+            <xs:enumeration value="dokumentobjekt"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="inkluderIMappe">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="mappe"/>
+            <xs:enumeration value="registrering"/>
+            <xs:enumeration value="klasse"/>
+            <xs:enumeration value="noekkelord"/>
+            <xs:enumeration value="kryssreferanse"/>
+            <xs:enumeration value="part"/>
+            <xs:enumeration value="merknad"/>
+            <xs:enumeration value="presedens"/>
+            <xs:enumeration value="moetedeltaker"/>
+            <xs:enumeration value="dokumentbeskrivelse"/>
+            <xs:enumeration value="korrespondansepart"/>
+            <xs:enumeration value="avskrivning"/>
+            <xs:enumeration value="dokumentflyt"/>
+            <xs:enumeration value="dokumentobjekt"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="inkluderISaksmappe">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="mappe"/>
+            <xs:enumeration value="registrering"/>
+            <xs:enumeration value="klasse"/>
+            <xs:enumeration value="noekkelord"/>
+            <xs:enumeration value="kryssreferanse"/>
+            <xs:enumeration value="part"/>
+            <xs:enumeration value="merknad"/>
+            <xs:enumeration value="presedens"/>
+            <xs:enumeration value="moetedeltaker"/>
+            <xs:enumeration value="dokumentbeskrivelse"/>
+            <xs:enumeration value="korrespondansepart"/>
+            <xs:enumeration value="avskrivning"/>
+            <xs:enumeration value="dokumentflyt"/>
+            <xs:enumeration value="dokumentobjekt"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="inkluderIRegistrering">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="klasse"/>
+            <xs:enumeration value="noekkelord"/>
+            <xs:enumeration value="kryssreferanse"/>
+            <xs:enumeration value="part"/>
+            <xs:enumeration value="merknad"/>
+            <xs:enumeration value="presedens"/>
+            <xs:enumeration value="moetedeltaker"/>
+            <xs:enumeration value="dokumentbeskrivelse"/>
+            <xs:enumeration value="korrespondansepart"/>
+            <xs:enumeration value="avskrivning"/>
+            <xs:enumeration value="dokumentflyt"/>
+            <xs:enumeration value="dokumentobjekt"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="inkluderIJournalpost">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="klasse"/>
+            <xs:enumeration value="noekkelord"/>
+            <xs:enumeration value="kryssreferanse"/>
+            <xs:enumeration value="part"/>
+            <xs:enumeration value="merknad"/>
+            <xs:enumeration value="presedens"/>
+            <xs:enumeration value="moetedeltaker"/>
+            <xs:enumeration value="dokumentbeskrivelse"/>
+            <xs:enumeration value="korrespondansepart"/>
+            <xs:enumeration value="avskrivning"/>
+            <xs:enumeration value="dokumentflyt"/>
+            <xs:enumeration value="dokumentobjekt"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="inkluderIDokumentbeskrivelse">
+        <xs:restriction base="xs:string">
             <xs:enumeration value="korrespondansepart"/>
             <xs:enumeration value="avskrivning"/>
             <xs:enumeration value="dokumentflyt"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
@@ -247,7 +247,6 @@
     <xs:simpleType name="inkluderIMappe">
         <xs:restriction base="xs:string">
             <xs:enumeration value="mappe"/>
-            <xs:enumeration value="registrering"/>
             <xs:enumeration value="noekkelord"/>
             <xs:enumeration value="kryssreferanse"/>
             <xs:enumeration value="part"/>
@@ -258,7 +257,6 @@
     <xs:simpleType name="inkluderISaksmappe">
         <xs:restriction base="xs:string">
             <xs:enumeration value="mappe"/>
-            <xs:enumeration value="registrering"/>
             <xs:enumeration value="noekkelord"/>
             <xs:enumeration value="kryssreferanse"/>
             <xs:enumeration value="part"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
@@ -274,11 +274,6 @@
             <xs:enumeration value="merknad"/>
             <xs:enumeration value="presedens"/>
             <xs:enumeration value="moetedeltaker"/>
-            <xs:enumeration value="dokumentbeskrivelse"/>
-            <xs:enumeration value="korrespondansepart"/>
-            <xs:enumeration value="avskrivning"/>
-            <xs:enumeration value="dokumentflyt"/>
-            <xs:enumeration value="dokumentobjekt"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
@@ -244,29 +244,9 @@
         </xs:complexContent>
     </xs:complexType>
 
-<!--    <xs:simpleType name="inkluder">-->
-<!--        <xs:restriction base="xs:string">-->
-<!--            <xs:enumeration value="mappe"/>-->
-<!--            <xs:enumeration value="registrering"/>-->
-<!--            <xs:enumeration value="klasse"/>-->
-<!--            <xs:enumeration value="noekkelord"/>-->
-<!--            <xs:enumeration value="kryssreferanse"/>-->
-<!--            <xs:enumeration value="part"/>-->
-<!--            <xs:enumeration value="merknad"/>-->
-<!--            <xs:enumeration value="presedens"/>-->
-<!--            <xs:enumeration value="moetedeltaker"/>-->
-<!--            <xs:enumeration value="dokumentbeskrivelse"/>-->
-<!--            <xs:enumeration value="korrespondansepart"/>-->
-<!--            <xs:enumeration value="avskrivning"/>-->
-<!--            <xs:enumeration value="dokumentflyt"/>-->
-<!--            <xs:enumeration value="dokumentobjekt"/>-->
-<!--        </xs:restriction>-->
-<!--    </xs:simpleType>-->
-
     <xs:simpleType name="inkluderIMappe">
         <xs:restriction base="xs:string">
             <xs:enumeration value="mappe"/>
-<!--            <xs:enumeration value="registrering"/>-->
             <xs:enumeration value="klasse"/>
             <xs:enumeration value="noekkelord"/>
             <xs:enumeration value="kryssreferanse"/>
@@ -289,25 +269,16 @@
             <xs:enumeration value="presedens"/>
             <xs:enumeration value="moetedeltaker"/>
             <xs:enumeration value="dokumentbeskrivelse"/>
-<!--            <xs:enumeration value="korrespondansepart"/>-->
-<!--            <xs:enumeration value="avskrivning"/>-->
-<!--            <xs:enumeration value="dokumentflyt"/>-->
-<!--            <xs:enumeration value="dokumentobjekt"/>-->
         </xs:restriction>
     </xs:simpleType>
 
     <xs:simpleType name="inkluderIRegistrering">
         <xs:restriction base="xs:string">
-<!--            <xs:enumeration value="klasse"/>-->
             <xs:enumeration value="noekkelord"/>
             <xs:enumeration value="kryssreferanse"/>
             <xs:enumeration value="part"/>
             <xs:enumeration value="merknad"/>
-<!--            <xs:enumeration value="presedens"/>-->
-<!--            <xs:enumeration value="moetedeltaker"/>-->
             <xs:enumeration value="dokumentbeskrivelse"/>
-<!--            <xs:enumeration value="korrespondansepart"/>-->
-<!--            <xs:enumeration value="avskrivning"/>-->
             <xs:enumeration value="dokumentflyt"/>
             <xs:enumeration value="dokumentobjekt"/>
         </xs:restriction>
@@ -315,13 +286,10 @@
 
     <xs:simpleType name="inkluderIJournalpost">
         <xs:restriction base="xs:string">
-<!--            <xs:enumeration value="klasse"/>-->
             <xs:enumeration value="noekkelord"/>
             <xs:enumeration value="kryssreferanse"/>
             <xs:enumeration value="part"/>
             <xs:enumeration value="merknad"/>
-<!--            <xs:enumeration value="presedens"/>-->
-<!--            <xs:enumeration value="moetedeltaker"/>-->
             <xs:enumeration value="dokumentbeskrivelse"/>
             <xs:enumeration value="korrespondansepart"/>
             <xs:enumeration value="avskrivning"/>
@@ -332,8 +300,6 @@
 
     <xs:simpleType name="inkluderIDokumentbeskrivelse">
         <xs:restriction base="xs:string">
-<!--            <xs:enumeration value="korrespondansepart"/>-->
-<!--            <xs:enumeration value="avskrivning"/>-->
             <xs:enumeration value="dokumentflyt"/>
             <xs:enumeration value="dokumentobjekt"/>
         </xs:restriction>


### PR DESCRIPTION
Dette et forslag og er ikke ferdig. Foreløpig kun for å kunne diskutere løsning.
Ref issue 99: https://github.com/ks-no/fiks-arkiv/issues/99

Har laget ny respons complextype som er forskjellig for hver type mtp hvilke inkluder felter man kan velge innenfor den typen. Spørsmålet er om sorteringsfelter også bør være forskjellig for hver responstype?