### PR TITLE
Endret kryssreferanse og lagt til at den kan oppdateres

### DIFF
--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -469,6 +469,7 @@
 
     <xs:complexType name="kryssreferanse">
         <xs:sequence>
+            <xs:element name="systemID" type="n5mdk:systemID"/>
             <xs:element name="referanseTilKlasse" type="n5mdk:referanseTilKlasse" minOccurs="0"/>
             <xs:element name="referanseTilMappe" type="n5mdk:referanseTilMappe" minOccurs="0"/>
             <xs:element name="referanseTilRegistrering" type="n5mdk:referanseTilRegistrering" minOccurs="0"/>

--- a/Schema/V1/metadatakatalog.xsd
+++ b/Schema/V1/metadatakatalog.xsd
@@ -519,19 +519,32 @@
     <xs:restriction base="ID"/>
   </xs:simpleType>
 
-  <xs:simpleType name="referanseTilMappe">
+  <xs:complexType name="referanseTilMappe">
     <xs:annotation>
       <xs:documentation>M210</xs:documentation>
+      <xs:documentation>Fiks-arkiv: endret datatypen fra en systemID til en complexType som kan inneholde en eller flere identifikatorer</xs:documentation>
     </xs:annotation>
-    <xs:restriction base="ID"/>
-  </xs:simpleType>
+    <xs:sequence>
+      <xs:element name="systemID" type="systemID" minOccurs="0"/>
+      <xs:element name="mappeID" type="mappeID" minOccurs="0"/>
+      <xs:element name="saksnummer" type="saksnummer" minOccurs="0"/>
+      <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
 
-  <xs:simpleType name="referanseTilRegistrering">
+  <xs:complexType name="referanseTilRegistrering">
     <xs:annotation>
       <xs:documentation>M212</xs:documentation>
+      <xs:documentation>Fiks-arkiv: endret datatypen fra en systemID til en complexType som kan inneholde en eller flere identifikatorer</xs:documentation>
     </xs:annotation>
-    <xs:restriction base="ID"/>
-  </xs:simpleType>
+    <xs:sequence>
+      <xs:element name="systemID" type="systemID" minOccurs="0"/>
+      <xs:element name="registreringsID" type="registreringsID" minOccurs="0"/>
+      <xs:element name="journalnummer" type="journalnummer" minOccurs="0"/>
+      <xs:element name="saksJournalpostnummer" type="saksJournalpostnummer" minOccurs="0"/>
+      <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
 
   <xs:simpleType name="referanseAvskrivesAvJournalpost">
     <xs:annotation>
@@ -1668,5 +1681,36 @@
       <xs:element name="kode" type="xs:string"/>
       <xs:element name="beskrivelse" type="xs:string" minOccurs="0"/>
     </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="saksnummer">
+    <xs:sequence>
+      <xs:element name="saksaar" type="saksaar" />
+      <xs:element name="sakssekvensnummer" type="sakssekvensnummer" />
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="eksternNoekkel">
+    <xs:sequence>
+      <xs:element name="fagsystem" type="fagsystem"/>
+      <xs:element name="noekkel" type="noekkel"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="journalnummer">
+    <xs:sequence>
+      <xs:element name="journalaar" type="journalaar"/>
+      <xs:element name="journalsekvensnummer" type="journalsekvensnummer"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="saksJournalpostnummer">
+    <xs:complexContent>
+      <xs:extension base="saksnummer">
+        <xs:sequence>
+          <xs:element name="journalpostnummer" type="journalpostnummer"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
   </xs:complexType>
 </xs:schema>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
@@ -32,6 +32,7 @@
             <xs:element name="beskrivelse" type="n5mdk:beskrivelse" minOccurs="0"/>
             <xs:element name="virksomhetsspesifikkeMetadata" type="xs:anyType" minOccurs="0"/>
             <xs:element name="partOppdatering" type="partOppdateringer" minOccurs="0"/>
+            <xs:element name="kryssreferanseOppdatering" type="kryssreferanseOppdateringer" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -48,6 +49,31 @@
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
+    </xs:complexType>
+    
+    <xs:complexType name="kryssreferanseOppdateringer">
+        <xs:sequence>
+            <xs:element name="oppdatering" type="kryssreferanseOppdatering" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="slett" type="kryssreferanseSlett" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="ny" type="arkivmelding:kryssreferanse" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <xs:complexType name="kryssreferanseOppdatering">
+        <xs:sequence>
+            <xs:element name="systemID" type="n5mdk:systemID"/>
+            <xs:element name="referanseTilKlasse" type="n5mdk:referanseTilKlasse" minOccurs="0"/>
+            <xs:element name="referanseTilMappe" type="n5mdk:referanseTilMappe" minOccurs="0"/>
+            <xs:element name="referanseTilRegistrering" type="n5mdk:referanseTilRegistrering" minOccurs="0"/>
+            <xs:element name="referanseTilDokumentbeskrivelse" type="n5mdk:referanseTilDokumentbeskrivelse"
+                        minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <xs:complexType name="kryssreferanseSlett">
+        <xs:sequence>
+            <xs:element name="systemID" type="n5mdk:systemID"/>
+        </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="punktOppdateringer">


### PR DESCRIPTION
Kryssreferanse kan nå oppdateres og referanseTilMappe og referanseTilRegistrering har flått flere identifikatorer

Ref [issue 84](https://github.com/ks-no/fiks-arkiv/issues/84). Men burde det være en choice mellom identifikatorene i referanseTilMappe og referanseTilRegistrering? Nå kan man putte inn flere enn 1 som kanskje burde være unødvendig? Eller ønsker vi at man får lov å sende inn alle identifikatorene hvis man har dem?