### PR TITLE
Refaktorert mtp at flere typer nå ligger i metadatakatalog

### DIFF
--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -186,7 +186,7 @@
             <xs:element name="skjerming" type="skjerming" minOccurs="0"/>
             <xs:element name="gradering" type="gradering" minOccurs="0"/>
             <xs:element name="klassifikasjon" type="klassifikasjon" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0"/>
+            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0"/>
             <xs:choice>
                 <xs:element name="mappe" type="mappe" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="registrering" type="registrering" minOccurs="0" maxOccurs="unbounded"/>
@@ -212,13 +212,6 @@
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
-    </xs:complexType>
-
-    <xs:complexType name="eksternNoekkel">
-        <xs:sequence>
-            <xs:element name="fagsystem" type="n5mdk:fagsystem"/>
-            <xs:element name="noekkel" type="n5mdk:noekkel"/>
-        </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="klassifikasjon">

--- a/Schema/V1/arkivstrukturMinimum.xsd
+++ b/Schema/V1/arkivstrukturMinimum.xsd
@@ -52,7 +52,7 @@
             <xs:element name="skjerming" type="skjermingMinimum" minOccurs="0"/>
             <xs:element name="gradering" type="graderingMinimum" minOccurs="0"/>
             <xs:element name="klassifikasjon" type="klassifikasjon" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0"/>
+            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0"/>
             <xs:choice>
                 <xs:element name="mappe" type="mappeMinimum" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="registrering" type="registreringMinimum" minOccurs="0" maxOccurs="unbounded"/>
@@ -155,13 +155,6 @@
             <xs:element name="gradertAv" type="n5mdk:gradertAv"/>
             <xs:element name="nedgraderingsdato" type="n5mdk:nedgraderingsdato" minOccurs="0"/>
             <xs:element name="nedgradertAv" type="n5mdk:nedgradertAv" minOccurs="0"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="eksternNoekkel">
-        <xs:sequence>
-            <xs:element name="fagsystem" type="n5mdk:fagsystem"/>
-            <xs:element name="noekkel" type="n5mdk:noekkel"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/Schema/V1/arkivstrukturNoekler.xsd
+++ b/Schema/V1/arkivstrukturNoekler.xsd
@@ -2,7 +2,6 @@
 <xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/noekler/v1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:n5mdk="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
-           xmlns:arkivstruktur="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
            targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/noekler/v1"
            elementFormDefault="qualified" attributeFormDefault="unqualified" version="5.0">
 
@@ -14,15 +13,13 @@
 
     <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
                schemaLocation="metadatakatalog.xsd"/>
-    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
-               schemaLocation="./arkivstruktur.xsd"/>
 
     <xs:complexType name="mappeNoekler">
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
             <xs:element name="mappeID" type="n5mdk:mappeID" minOccurs="0"/>
             <xs:element minOccurs="0" name="ReferanseForeldermappe" type="n5mdk:systemID"/>
-            <xs:element name="referanseEksternNoekkel" type="arkivstruktur:eksternNoekkel" minOccurs="0"/>
+            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0"/>
             <xs:choice>
                 <xs:element name="mappe" type="mappeNoekler" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="registrering" type="registreringNoekler" minOccurs="0" maxOccurs="unbounded"/>
@@ -34,7 +31,7 @@
         <xs:complexContent>
             <xs:extension base="mappeNoekler">
                 <xs:sequence>
-                    <xs:element name="saksnummer" type="saksnummer" minOccurs="0"/>
+                    <xs:element name="saksnummer" type="n5mdk:saksnummer" minOccurs="0"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
@@ -50,11 +47,11 @@
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
             <xs:choice minOccurs="0">
-                <xs:element name="referanseForelderMappe" type="referanseForelderMappe"/>
+                <xs:element name="referanseForelderMappe" type="n5mdk:referanseTilMappe"/>
                 <xs:element name="arkivdel" type="n5mdk:kode"/>
             </xs:choice>
             <xs:element name="dokumentbeskrivelse" type="dokumentbeskrivelseNoekler" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="referanseEksternNoekkel" type="arkivstruktur:eksternNoekkel"/>
+            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -75,21 +72,6 @@
     <xs:complexType name="dokumentbeskrivelseNoekler">
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="referanseForelderMappe">
-        <xs:choice>
-            <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
-            <xs:element name="referanseEksternNoekkel" type="arkivstruktur:eksternNoekkel" minOccurs="0"/>
-            <xs:element name="saksnummer" type="saksnummer" minOccurs="0"/>
-        </xs:choice>
-    </xs:complexType>
-
-    <xs:complexType name="saksnummer">
-        <xs:sequence>
-            <xs:element name="saksaar" type="n5mdk:saksaar" />
-            <xs:element name="sakssekvensnummer" type="n5mdk:sakssekvensnummer" />
         </xs:sequence>
     </xs:complexType>
 

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.xsd
@@ -46,7 +46,7 @@
             <xs:element name="skjerming" type="skjerming" minOccurs="0"/>
             <xs:element name="gradering" type="gradering" minOccurs="0"/>
             <xs:element name="klassifikasjon" type="klassifikasjon" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0"/>
+            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0"/>
             <!-- Tillater mapper uten forekomster av (under)mappe og registrering -->
             <xs:choice>
                 <xs:element name="mappe" type="mappe" minOccurs="0" maxOccurs="unbounded"/>
@@ -148,7 +148,7 @@
             <xs:element name="kryssreferanse" type="kryssreferanse" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="korrespondansepart" type="korrespondansepart" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="klassifikasjon" type="klassifikasjon" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="referanseEksternNoekkel" type="eksternNoekkel"/>
+            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -375,23 +375,9 @@
     <xs:complexType name="referanseForelderMappe">
         <xs:choice>
             <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
-            <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0"/>
-            <xs:element name="saksnummer" type="saksnummer" minOccurs="0"/>
+            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0"/>
+            <xs:element name="saksnummer" type="n5mdk:saksnummer" minOccurs="0"/>
         </xs:choice>
-    </xs:complexType>
-
-    <xs:complexType name="saksnummer">
-        <xs:sequence>
-            <xs:element name="saksaar" type="n5mdk:saksaar" />
-            <xs:element name="sakssekvensnummer" type="n5mdk:sakssekvensnummer" />
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="eksternNoekkel">
-        <xs:sequence>
-            <xs:element name="fagsystem" type="n5mdk:fagsystem"/>
-            <xs:element name="noekkel" type="n5mdk:noekkel"/>
-        </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="merknad">
@@ -492,28 +478,11 @@
     <xs:complexType name="referanseJournalpost">
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
-            <xs:element name="journalnummer" type="journalnummer" minOccurs="0"/>
-            <xs:element name="saksJournalpostnummer" type="saksJournalpostnummer" minOccurs="0"/>
-            <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="journalnummer" type="n5mdk:journalnummer" minOccurs="0"/>
+            <xs:element name="saksJournalpostnummer" type="n5mdk:saksJournalpostnummer" minOccurs="0"/>
+            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0" maxOccurs="1"/>
             <xs:element name="registreringsID" type="n5mdk:registreringsID" minOccurs="0"/>
         </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="journalnummer">
-        <xs:sequence>
-            <xs:element name="journalaar" type="n5mdk:journalaar"/>
-            <xs:element name="journalsekvensnummer" type="n5mdk:journalsekvensnummer"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="saksJournalpostnummer">
-        <xs:complexContent>
-            <xs:extension base="saksnummer">
-                <xs:sequence>
-                    <xs:element name="journalpostnummer" type="n5mdk:journalpostnummer"/>
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
     </xs:complexType>
 
 </xs:schema>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.mappe.hent.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.mappe.hent.xsd
@@ -15,27 +15,11 @@
 
     <xs:complexType name="mappeHent">
         <xs:sequence>
-            <xs:element name="referanseMappe" type="referanseMappe"/>
+            <xs:element name="referanseMappe" type="n5mdk:referanseTilMappe"/>
             <xs:element name="inkluder" type="inkluder" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 
-    <xs:complexType name="referanseMappe">
-        <xs:sequence>
-            <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
-            <xs:element name="mappeID" type="n5mdk:mappeID" minOccurs="0"/>
-            <xs:element name="saksnummer" type="saksnummer" minOccurs="0"/>
-            <xs:element name="referanseEksternNoekkel" type="arkivstruktur:eksternNoekkel" minOccurs="0"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="saksnummer">
-        <xs:sequence>
-            <xs:element name="saksaar" type="n5mdk:saksaar" />
-            <xs:element name="sakssekvensnummer" type="n5mdk:sakssekvensnummer" />
-        </xs:sequence>
-    </xs:complexType>
-    
     <xs:simpleType name="inkluder">
         <xs:restriction base="xs:string">
             <xs:enumeration value="merknad"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.registrering.hent.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.registrering.hent.xsd
@@ -14,49 +14,8 @@
 	
 	<xs:complexType name="registreringHent">
 		<xs:sequence>
-			<xs:element name="referanseRegistrering" type="referanseRegistrering"/>
+			<xs:element name="referanseRegistrering" type="n5mdk:referanseTilRegistrering"/>
 			<xs:element name="inkluder" type="inkluder" minOccurs="0"/>
-		</xs:sequence>
-	</xs:complexType>
-
-	<xs:complexType name="referanseRegistrering">
-		<xs:sequence>
-			<xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
-			<xs:element name="journalnummer" type="journalnummer" minOccurs="0"/>
-			<xs:element name="saksJournalpostnummer" type="saksJournalpostnummer" minOccurs="0"/>
-			<xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0" maxOccurs="1"/>
-			<xs:element name="registreringsID" type="n5mdk:registreringsID" minOccurs="0"/>
-		</xs:sequence>
-	</xs:complexType>
-
-	<xs:complexType name="saksnummer">
-		<xs:sequence>
-			<xs:element name="saksaar" type="n5mdk:saksaar" />
-			<xs:element name="sakssekvensnummer" type="n5mdk:sakssekvensnummer" />
-		</xs:sequence>
-	</xs:complexType>
-
-	<xs:complexType name="journalnummer">
-		<xs:sequence>
-			<xs:element name="journalaar" type="n5mdk:journalaar"/>
-			<xs:element name="journalsekvensnummer" type="n5mdk:journalsekvensnummer"/>
-		</xs:sequence>
-	</xs:complexType>
-
-	<xs:complexType name="saksJournalpostnummer">
-		<xs:complexContent>
-			<xs:extension base="saksnummer">
-				<xs:sequence>
-					<xs:element name="journalpostnummer" type="n5mdk:journalpostnummer"/>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-
-	<xs:complexType name="eksternNoekkel">
-		<xs:sequence>
-			<xs:element name="fagsystem" type="n5mdk:fagsystem"/>
-			<xs:element name="noekkel" type="n5mdk:noekkel"/>
 		</xs:sequence>
 	</xs:complexType>
 


### PR DESCRIPTION
Refaktorert og slettet duplikat kode mtp at flere typer nå ligger i metadatakatalog

Dette gjelder blant annet eksternNoekkel, referanseTilMappe, referanseTilRegistrering og saksnummer. 