### PR TITLE
Fikset feil i referanser etter refaktorering

### DIFF
--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -294,7 +294,7 @@
             <xs:element name="kryssreferanse" type="kryssreferanse" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="korrespondansepart" type="korrespondansepart" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="klassifikasjon" type="klassifikasjon" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="referanseEksternNoekkel" type="eksternNoekkel"/>
+            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.kvittering.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.kvittering.xsd
@@ -34,7 +34,7 @@
             <xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
             <xs:element name="avsluttetDato" type="n5mdk:avsluttetDato" minOccurs="0"/>
             <xs:element name="avsluttetAv" type="n5mdk:avsluttetAv" minOccurs="0"/>
-            <xs:element name="referanseEksternNoekkel" type="arkivstruktur:eksternNoekkel" minOccurs="0"/>
+            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0"/>
             <xs:choice>
                 <xs:element name="mappeKvittering" type="mappeKvittering" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="registreringKvittering" type="registreringKvittering" minOccurs="0"
@@ -65,7 +65,7 @@
             <xs:element name="dokumentbeskrivelseKvittering" type="dokumentbeskrivelseKvittering" minOccurs="0"
                         maxOccurs="unbounded"/>
             <xs:element name="registreringsID" type="n5mdk:registreringsID" minOccurs="0"/>
-            <xs:element name="referanseEksternNoekkel" type="arkivstruktur:eksternNoekkel" minOccurs="0"/>
+            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
@@ -25,7 +25,7 @@
         <xs:sequence>
             <xs:choice>
                 <xs:element name="systemID" type="n5mdk:systemID"/>
-                <xs:element name="referanseEksternNoekkel" type="arkivmelding:eksternNoekkel"/>
+                <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel"/>
             </xs:choice>
             <xs:element name="tittel" type="n5mdk:tittel" minOccurs="0"/>
             <xs:element name="offentligTittel" type="n5mdk:offentligTittel" minOccurs="0"/>
@@ -156,7 +156,7 @@
         <xs:sequence>
             <xs:choice>
                 <xs:element name="systemID" type="n5mdk:systemID"/>
-                <xs:element name="referanseEksternNoekkel" type="arkivmelding:eksternNoekkel"/>
+                <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel"/>
             </xs:choice>
             <xs:element name="partOppdatering" type="partOppdateringer" minOccurs="0"/>
             <xs:element name="skjerming" type="arkivmelding:skjerming" minOccurs="0"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
@@ -18,7 +18,6 @@
             <xs:element name="respons" type="respons"/>
             <xs:element name="parameter" type="parameter" maxOccurs="unbounded"/>
             <xs:element name="responsType" type="arkivstruktur:responsType" default="minimum"/>
-            <xs:element name="inkluder" type="inkluder" minOccurs="0"/>
             <xs:element name="sortering" type="sortering" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>


### PR DESCRIPTION
Fikset feil i referanser etter refaktorering

Etter vi flyttet eksternNoekkel til metadatakatalog har dette oppstått. Var sikker på vi hadde fikset alle referanser, men tydeligvis ikke. Eller det har blitt noe tull med merging av flere pull-requests. 