### PR TITLE
Refaktorering av søk og splitting av søkefelt og sorteringfelt

### DIFF
--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
@@ -383,7 +383,7 @@
 
     <xs:complexType name="saksmappeSortering">
         <xs:sequence>
-            <xs:element name="felt" type="saksmappeSorteringsfelt"/>
+            <xs:element name="felt" type="mappeOgSaksmappeSorteringsfelt"/>
             <xs:element name="type" type="sorteringType"/>
         </xs:sequence>
     </xs:complexType>
@@ -397,7 +397,7 @@
 
     <xs:complexType name="journalpostSortering">
         <xs:sequence>
-            <xs:element name="felt" type="journalpostSorteringsfelt"/>
+            <xs:element name="felt" type="registreringOgJournalpostSorteringsfelt"/>
             <xs:element name="type" type="sorteringType"/>
         </xs:sequence>
     </xs:complexType>
@@ -428,6 +428,10 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="mappeOgSaksmappeSorteringsfelt">
+        <xs:union memberTypes="mappeSorteringsfelt saksmappeSorteringsfelt" />
+    </xs:simpleType>
+
     <xs:simpleType name="registreringSorteringsfelt">
         <xs:restriction base="xs:string">
             <xs:enumeration value="registreringOpprettetDato"/>
@@ -440,6 +444,10 @@
             <xs:enumeration value="journalpostJournalaar-journalsekvensnummer"/>
             <xs:enumeration value="journalpostJournalpostnummer"/>
         </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="registreringOgJournalpostSorteringsfelt">
+        <xs:union memberTypes="registreringSorteringsfelt journalpostSorteringsfelt" />
     </xs:simpleType>
 
     <xs:simpleType name="dokumentbeskrivelseSorteringsfelt">

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
@@ -106,7 +106,7 @@
         <xs:complexContent>
             <xs:extension base="parameter">
                 <xs:sequence>
-                    <xs:element name="felt" type="mappeOgSaksmappeSokefelt"/>
+                    <xs:element name="felt" type="saksmappeSorteringsfelt"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
@@ -126,7 +126,7 @@
         <xs:complexContent>
             <xs:extension base="parameter">
                 <xs:sequence>
-                    <xs:element name="felt" type="registreringOgJournalpostSokefelt"/>
+                    <xs:element name="felt" type="journalpostSorteringsfelt"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
@@ -231,6 +231,34 @@
 
     <xs:simpleType name="saksmappeSokefelt">
         <xs:restriction base="xs:string">
+            <xs:enumeration value="mappeEksternId"/>
+            <xs:enumeration value="mappeTittel"/>
+            <xs:enumeration value="mappeOpprettetDato"/>
+            <xs:enumeration value="mappeBeskrivelse"/>
+            <xs:enumeration value="mappeNoekkelord"/>
+            <xs:enumeration value="mappeAvsluttetDato"/>
+            <xs:enumeration value="mappeArkivdel"/>
+            <xs:enumeration value="mappeEndretFoerDato"/>
+            <xs:enumeration value="mappeEndretEtterDato"/>
+            <xs:enumeration value="mappeMappetype"/>
+
+            <xs:enumeration value="mappeKlasseKlassifikasjonssystem"/>
+            <xs:enumeration value="mappeKlasseKlasseID"/>
+            <xs:enumeration value="mappeKlasseTittel"/>
+            <xs:enumeration value="mappeKlasseBeskrivelse"/>
+
+            <xs:enumeration value="mappePartPartNavn"/>
+            <xs:enumeration value="mappePartPartRolle"/>
+            <xs:enumeration value="mappePartPostadresse"/>
+            <xs:enumeration value="mappePartPostnummer"/>
+            <xs:enumeration value="mappePartPoststed"/>
+            <xs:enumeration value="mappePartEpostadresse"/>
+
+            <xs:enumeration value="mappeSkjermingTilgangsrestriksjon"/>
+            <xs:enumeration value="mappeSkjermingSkjermingshjemmel"/>
+            <xs:enumeration value="mappeSkjermingSkjermingsvarighet"/>
+            <xs:enumeration value="mappeSkjermingSkjermingOpphoererDato"/>
+            
             <xs:enumeration value="sakSaksdato"/>
             <xs:enumeration value="sakSaksaar"/>
             <xs:enumeration value="sakSaksekvensnummer"/>
@@ -260,10 +288,6 @@
             <xs:enumeration value="sakPunktZ"/>
         </xs:restriction>
     </xs:simpleType>
-    
-    <xs:simpleType name="mappeOgSaksmappeSokefelt">
-        <xs:union memberTypes="mappeSokefelt saksmappeSokefelt" />
-    </xs:simpleType>
 
     <xs:simpleType name="registreringSokefelt">
         <xs:restriction base="xs:string">
@@ -291,6 +315,26 @@
     
     <xs:simpleType name="journalpostSokefelt">
         <xs:restriction base="xs:string">
+            <xs:enumeration value="registreringEksternId"/>
+            <xs:enumeration value="registreringOpprettetDato"/>
+            <xs:enumeration value="registreringTittel"/>
+            <xs:enumeration value="registreringAdministrativenhet"/>
+            <xs:enumeration value="registreringJournalpostansvarlig"/>
+            <xs:enumeration value="registreringEndretFoerDato"/>
+            <xs:enumeration value="registreringEndretEtterDato"/>
+
+            <xs:enumeration value="registreringPartPartNavn"/>
+            <xs:enumeration value="registreringPartPartRolle"/>
+            <xs:enumeration value="registreringPartPostadresse"/>
+            <xs:enumeration value="registreringPartPostnummer"/>
+            <xs:enumeration value="registreringPartPoststed"/>
+            <xs:enumeration value="registreringPartEpostadresse"/>
+
+            <xs:enumeration value="registreringSkjermingTilgangsrestriksjon"/>
+            <xs:enumeration value="registreringSkjermingSkjermingshjemmel"/>
+            <xs:enumeration value="registreringSkjermingSkjermingsvarighet"/>
+            <xs:enumeration value="registreringSkjermingSkjermingOpphoererDato"/>
+            
             <xs:enumeration value="journalpostJournalaar"/>
             <xs:enumeration value="journalpostJournalsekvensnummer"/>
             <xs:enumeration value="journalpostSaksaar"/>
@@ -302,10 +346,6 @@
             <xs:enumeration value="journalpostDokumentetsdato"/>
             <xs:enumeration value="journalpostForfallsdato"/>
         </xs:restriction>
-    </xs:simpleType>
-
-    <xs:simpleType name="registreringOgJournalpostSokefelt">
-        <xs:union memberTypes="registreringSokefelt journalpostSokefelt" />
     </xs:simpleType>
 
     <xs:simpleType name="dokumentbeskrivelseSokefelt">
@@ -383,7 +423,7 @@
 
     <xs:complexType name="saksmappeSortering">
         <xs:sequence>
-            <xs:element name="felt" type="mappeOgSaksmappeSorteringsfelt"/>
+            <xs:element name="felt" type="saksmappeSorteringsfelt"/>
             <xs:element name="type" type="sorteringType"/>
         </xs:sequence>
     </xs:complexType>
@@ -397,7 +437,7 @@
 
     <xs:complexType name="journalpostSortering">
         <xs:sequence>
-            <xs:element name="felt" type="registreringOgJournalpostSorteringsfelt"/>
+            <xs:element name="felt" type="journalpostSorteringsfelt"/>
             <xs:element name="type" type="sorteringType"/>
         </xs:sequence>
     </xs:complexType>
@@ -424,12 +464,9 @@
 
     <xs:simpleType name="saksmappeSorteringsfelt">
         <xs:restriction base="xs:string">
+            <xs:enumeration value="mappeOpprettetDato"/>
             <xs:enumeration value="sakSaksaar-saksekvensnummer"/>
         </xs:restriction>
-    </xs:simpleType>
-
-    <xs:simpleType name="mappeOgSaksmappeSorteringsfelt">
-        <xs:union memberTypes="mappeSorteringsfelt saksmappeSorteringsfelt" />
     </xs:simpleType>
 
     <xs:simpleType name="registreringSorteringsfelt">
@@ -440,14 +477,11 @@
 
     <xs:simpleType name="journalpostSorteringsfelt">
         <xs:restriction base="xs:string">
+            <xs:enumeration value="registreringOpprettetDato"/>
             <xs:enumeration value="journalpostJournaldato"/>
             <xs:enumeration value="journalpostJournalaar-journalsekvensnummer"/>
             <xs:enumeration value="journalpostJournalpostnummer"/>
         </xs:restriction>
-    </xs:simpleType>
-
-    <xs:simpleType name="registreringOgJournalpostSorteringsfelt">
-        <xs:union memberTypes="registreringSorteringsfelt journalpostSorteringsfelt" />
     </xs:simpleType>
 
     <xs:simpleType name="dokumentbeskrivelseSorteringsfelt">

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
@@ -106,7 +106,7 @@
         <xs:complexContent>
             <xs:extension base="parameter">
                 <xs:sequence>
-                    <xs:element name="felt" type="saksmappeSorteringsfelt"/>
+                    <xs:element name="felt" type="saksmappeSokefelt"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
@@ -126,7 +126,7 @@
         <xs:complexContent>
             <xs:extension base="parameter">
                 <xs:sequence>
-                    <xs:element name="felt" type="journalpostSorteringsfelt"/>
+                    <xs:element name="felt" type="journalpostSokefelt"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
@@ -15,22 +15,134 @@
             <xs:element name="tidspunkt" type="xs:dateTime"/>
             <xs:element name="take" type="xs:int"/>
             <xs:element name="skip" type="xs:int"/>
-            <xs:element name="respons" type="respons"/>
-            <xs:element name="parameter" type="parameter" maxOccurs="unbounded"/>
-            <xs:element name="responsType" type="arkivstruktur:responsType" default="minimum"/>
-            <xs:element name="sortering" type="sortering" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="sokdefinisjon" type="sokdefinisjon"/>
         </xs:sequence>
     </xs:complexType>
 
-    <xs:complexType name="parameter">
+    <xs:complexType name="sokdefinisjon" abstract="true">
         <xs:sequence>
-            <xs:element name="felt" type="sokFelt"/>
-            <xs:element name="operator" type="operatorType"/>
-            <xs:element name="parameterverdier" type="parameterverdier"/>
+            <xs:element name="responsType" type="arkivstruktur:responsType" default="minimum"/>
         </xs:sequence>
     </xs:complexType>
 
-    <xs:complexType name="parameterverdier">
+    <xs:complexType name="mappeSokdefinisjon">
+        <xs:complexContent>
+            <xs:extension base="sokdefinisjon">
+                <xs:sequence>
+                    <xs:element name="inkluder" type="mappeInkluder" maxOccurs="unbounded"/>
+                    <xs:element name="parametere" type="mappeParameter" maxOccurs="unbounded"/>
+                    <xs:element name="sortering" type="mappeSortering" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="saksmappeSokdefinisjon">
+        <xs:complexContent>
+            <xs:extension base="sokdefinisjon">
+                <xs:sequence>
+                    <xs:element name="inkluder" type="saksmappeInkluder" maxOccurs="unbounded"/>
+                    <xs:element name="parametere" type="saksmappeParameter" maxOccurs="unbounded"/>
+                    <xs:element name="sortering" type="saksmappeSortering" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="registreringSokdefinisjon">
+        <xs:complexContent>
+            <xs:extension base="sokdefinisjon">
+                <xs:sequence>
+                    <xs:element name="inkluder" type="registreringInkluder" maxOccurs="unbounded"/>
+                    <xs:element name="parametere" type="registreringParameter" maxOccurs="unbounded"/>
+                    <xs:element name="sortering" type="registreringSortering" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="journalpostSokdefinisjon">
+        <xs:complexContent>
+            <xs:extension base="sokdefinisjon">
+                <xs:sequence>
+                    <xs:element name="inkluder" type="journalpostInkluder" maxOccurs="unbounded"/>
+                    <xs:element name="parametere" type="journalpostParameter" maxOccurs="unbounded"/>
+                    <xs:element name="sortering" type="journalpostSortering" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="dokumentbeskrivelseSokdefinisjon">
+        <xs:complexContent>
+            <xs:extension base="sokdefinisjon">
+                <xs:sequence>
+                    <xs:element name="inkluder" type="dokumentbeskrivelseInkluder" maxOccurs="unbounded"/>
+                    <xs:element name="parametere" type="dokumentbeskrivelseParameter" maxOccurs="unbounded"/>
+                    <xs:element name="sortering" type="dokumentbeskrivelseSortering" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="parameter" abstract="true">
+        <xs:sequence>
+            <xs:element name="operator" type="operatorType"/>
+            <xs:element name="sokVerdier" type="sokVerdier"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="mappeParameter">
+        <xs:complexContent>
+            <xs:extension base="parameter">
+                <xs:sequence>
+                    <xs:element name="felt" type="mappeSokefelt"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="saksmappeParameter">
+        <xs:complexContent>
+            <xs:extension base="parameter">
+                <xs:sequence>
+                    <xs:element name="felt" type="mappeOgSaksmappeSokefelt"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="registreringParameter">
+        <xs:complexContent>
+            <xs:extension base="parameter">
+                <xs:sequence>
+                    <xs:element name="felt" type="registreringSokefelt"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="journalpostParameter">
+        <xs:complexContent>
+            <xs:extension base="parameter">
+                <xs:sequence>
+                    <xs:element name="felt" type="registreringOgJournalpostSokefelt"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="dokumentbeskrivelseParameter">
+        <xs:complexContent>
+            <xs:extension base="parameter">
+                <xs:sequence>
+                    <xs:element name="felt" type="dokumentbeskrivelseSokefelt"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="sokVerdier">
         <xs:choice minOccurs="0">
             <xs:element name="stringvalues" type="stringvalues"/>
             <xs:element name="datevalues" type="datevalues"/>
@@ -85,7 +197,7 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:simpleType name="sokFelt">
+    <xs:simpleType name="mappeSokefelt">
         <xs:restriction base="xs:string">
             <xs:enumeration value="mappeEksternId"/>
             <xs:enumeration value="mappeTittel"/>
@@ -97,30 +209,34 @@
             <xs:enumeration value="mappeEndretFoerDato"/>
             <xs:enumeration value="mappeEndretEtterDato"/>
             <xs:enumeration value="mappeMappetype"/>
-
-            <xs:enumeration value="sakSaksdato"/>
-            <xs:enumeration value="sakSaksaar"/>
-            <xs:enumeration value="sakSaksekvensnummer"/>
-            <xs:enumeration value="sakSaksstatus"/>
-            <xs:enumeration value="sakAdministrativenhet"/>
-            <xs:enumeration value="sakSaksansvarlig"/>
-
+    
             <xs:enumeration value="mappeKlasseKlassifikasjonssystem"/>
             <xs:enumeration value="mappeKlasseKlasseID"/>
             <xs:enumeration value="mappeKlasseTittel"/>
             <xs:enumeration value="mappeKlasseBeskrivelse"/>
-
+    
             <xs:enumeration value="mappePartPartNavn"/>
             <xs:enumeration value="mappePartPartRolle"/>
             <xs:enumeration value="mappePartPostadresse"/>
             <xs:enumeration value="mappePartPostnummer"/>
             <xs:enumeration value="mappePartPoststed"/>
             <xs:enumeration value="mappePartEpostadresse"/>
-
+    
             <xs:enumeration value="mappeSkjermingTilgangsrestriksjon"/>
             <xs:enumeration value="mappeSkjermingSkjermingshjemmel"/>
             <xs:enumeration value="mappeSkjermingSkjermingsvarighet"/>
             <xs:enumeration value="mappeSkjermingSkjermingOpphoererDato"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="saksmappeSokefelt">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="sakSaksdato"/>
+            <xs:enumeration value="sakSaksaar"/>
+            <xs:enumeration value="sakSaksekvensnummer"/>
+            <xs:enumeration value="sakSaksstatus"/>
+            <xs:enumeration value="sakAdministrativenhet"/>
+            <xs:enumeration value="sakSaksansvarlig"/>
 
             <xs:enumeration value="sakMatrikkelnummerKommunenummer"/>
             <xs:enumeration value="sakMatrikkelnummerGaardsnummer"/>
@@ -142,7 +258,15 @@
             <xs:enumeration value="sakPunktX"/>
             <xs:enumeration value="sakPunktY"/>
             <xs:enumeration value="sakPunktZ"/>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <xs:simpleType name="mappeOgSaksmappeSokefelt">
+        <xs:union memberTypes="mappeSokefelt saksmappeSokefelt" />
+    </xs:simpleType>
 
+    <xs:simpleType name="registreringSokefelt">
+        <xs:restriction base="xs:string">
             <xs:enumeration value="registreringEksternId"/>
             <xs:enumeration value="registreringOpprettetDato"/>
             <xs:enumeration value="registreringTittel"/>
@@ -162,7 +286,11 @@
             <xs:enumeration value="registreringSkjermingSkjermingshjemmel"/>
             <xs:enumeration value="registreringSkjermingSkjermingsvarighet"/>
             <xs:enumeration value="registreringSkjermingSkjermingOpphoererDato"/>
-
+        </xs:restriction>
+    </xs:simpleType>    
+    
+    <xs:simpleType name="journalpostSokefelt">
+        <xs:restriction base="xs:string">
             <xs:enumeration value="journalpostJournalaar"/>
             <xs:enumeration value="journalpostJournalsekvensnummer"/>
             <xs:enumeration value="journalpostSaksaar"/>
@@ -173,7 +301,15 @@
             <xs:enumeration value="journalpostJournaldato"/>
             <xs:enumeration value="journalpostDokumentetsdato"/>
             <xs:enumeration value="journalpostForfallsdato"/>
+        </xs:restriction>
+    </xs:simpleType>
 
+    <xs:simpleType name="registreringOgJournalpostSokefelt">
+        <xs:union memberTypes="registreringSokefelt journalpostSokefelt" />
+    </xs:simpleType>
+
+    <xs:simpleType name="dokumentbeskrivelseSokefelt">
+        <xs:restriction base="xs:string">
             <xs:enumeration value="dokumentbeskrivelseEksternId"/>
             <xs:enumeration value="dokumentbeskrivelseOpprettetDato"/>
             <xs:enumeration value="dokumentbeskrivelseTittel"/>
@@ -184,66 +320,10 @@
             <xs:enumeration value="dokumentbeskrivelseSkjermingSkjermingshjemmel"/>
             <xs:enumeration value="dokumentbeskrivelseSkjermingSkjermingsvarighet"/>
             <xs:enumeration value="dokumentbeskrivelseSkjermingSkjermingOpphoererDato"/>
-
         </xs:restriction>
     </xs:simpleType>
-
-    <!-- The respons is strict, meaning that the result should return the exact type set here. E.g. when set to mappe it should only return mappe in resultList -->
-    <xs:complexType name="respons">
-        
-    </xs:complexType>
-
-    <xs:complexType name="mappeRespons">
-        <xs:complexContent>
-            <xs:extension base="respons">
-                <xs:sequence>
-                    <xs:element name="inkluder" type="inkluderIMappe" maxOccurs="unbounded"/>
-                </xs:sequence> 
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
-    <xs:complexType name="saksmappeRespons">
-        <xs:complexContent>
-            <xs:extension base="respons">
-                <xs:sequence>
-                    <xs:element name="inkluder" type="inkluderISaksmappe" maxOccurs="unbounded"/>
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
-    <xs:complexType name="registreringRespons">
-        <xs:complexContent>
-            <xs:extension base="respons">
-                <xs:sequence>
-                    <xs:element name="inkluder" type="inkluderIRegistrering" maxOccurs="unbounded"/>
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
-    <xs:complexType name="journalpostRespons">
-        <xs:complexContent>
-            <xs:extension base="respons">
-                <xs:sequence>
-                    <xs:element name="inkluder" type="inkluderIJournalpost" maxOccurs="unbounded"/>
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
-    <xs:complexType name="dokumentbeskrivelseRespons">
-        <xs:complexContent>
-            <xs:extension base="respons">
-                <xs:sequence>
-                    <xs:element name="inkluder" type="inkluderIDokumentbeskrivelse" maxOccurs="unbounded"/>
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
-    <xs:simpleType name="inkluderIMappe">
+    
+    <xs:simpleType name="mappeInkluder">
         <xs:restriction base="xs:string">
             <xs:enumeration value="mappe"/>
             <xs:enumeration value="noekkelord"/>
@@ -253,7 +333,7 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:simpleType name="inkluderISaksmappe">
+    <xs:simpleType name="saksmappeInkluder">
         <xs:restriction base="xs:string">
             <xs:enumeration value="mappe"/>
             <xs:enumeration value="noekkelord"/>
@@ -264,7 +344,7 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:simpleType name="inkluderIRegistrering">
+    <xs:simpleType name="registreringInkluder">
         <xs:restriction base="xs:string">
             <xs:enumeration value="noekkelord"/>
             <xs:enumeration value="kryssreferanse"/>
@@ -275,7 +355,7 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:simpleType name="inkluderIJournalpost">
+    <xs:simpleType name="journalpostInkluder">
         <xs:restriction base="xs:string">
             <xs:enumeration value="noekkelord"/>
             <xs:enumeration value="kryssreferanse"/>
@@ -288,15 +368,43 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:simpleType name="inkluderIDokumentbeskrivelse">
+    <xs:simpleType name="dokumentbeskrivelseInkluder">
         <xs:restriction base="xs:string">
             <xs:enumeration value="dokumentobjekt"/>
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:complexType name="sortering">
+    <xs:complexType name="mappeSortering">
         <xs:sequence>
-            <xs:element name="felt" type="sorteringFelt"/>
+            <xs:element name="felt" type="mappeSorteringsfelt"/>
+            <xs:element name="type" type="sorteringType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="saksmappeSortering">
+        <xs:sequence>
+            <xs:element name="felt" type="saksmappeSorteringsfelt"/>
+            <xs:element name="type" type="sorteringType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="registreringSortering">
+        <xs:sequence>
+            <xs:element name="felt" type="registreringSorteringsfelt"/>
+            <xs:element name="type" type="sorteringType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="journalpostSortering">
+        <xs:sequence>
+            <xs:element name="felt" type="journalpostSorteringsfelt"/>
+            <xs:element name="type" type="sorteringType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="dokumentbeskrivelseSortering">
+        <xs:sequence>
+            <xs:element name="felt" type="dokumentbeskrivelseSorteringsfelt"/>
             <xs:element name="type" type="sorteringType"/>
         </xs:sequence>
     </xs:complexType>
@@ -308,14 +416,35 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:simpleType name="sorteringFelt">
+    <xs:simpleType name="mappeSorteringsfelt">
         <xs:restriction base="xs:string">
             <xs:enumeration value="mappeOpprettetDato"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="saksmappeSorteringsfelt">
+        <xs:restriction base="xs:string">
             <xs:enumeration value="sakSaksaar-saksekvensnummer"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="registreringSorteringsfelt">
+        <xs:restriction base="xs:string">
             <xs:enumeration value="registreringOpprettetDato"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="journalpostSorteringsfelt">
+        <xs:restriction base="xs:string">
             <xs:enumeration value="journalpostJournaldato"/>
             <xs:enumeration value="journalpostJournalaar-journalsekvensnummer"/>
             <xs:enumeration value="journalpostJournalpostnummer"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="dokumentbeskrivelseSorteringsfelt">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="opprettetDato"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
@@ -197,7 +197,7 @@
         <xs:complexContent>
             <xs:extension base="respons">
                 <xs:sequence>
-                    <xs:element name="inkluder" type="inkluderIMappe"/>
+                    <xs:element name="inkluder" type="inkluderIMappe" maxOccurs="unbounded"/>
                 </xs:sequence> 
             </xs:extension>
         </xs:complexContent>
@@ -207,7 +207,7 @@
         <xs:complexContent>
             <xs:extension base="respons">
                 <xs:sequence>
-                    <xs:element name="inkluder" type="inkluderISaksmappe"/>
+                    <xs:element name="inkluder" type="inkluderISaksmappe" maxOccurs="unbounded"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
@@ -217,7 +217,7 @@
         <xs:complexContent>
             <xs:extension base="respons">
                 <xs:sequence>
-                    <xs:element name="inkluder" type="inkluderIRegistrering"/>
+                    <xs:element name="inkluder" type="inkluderIRegistrering" maxOccurs="unbounded"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
@@ -227,7 +227,7 @@
         <xs:complexContent>
             <xs:extension base="respons">
                 <xs:sequence>
-                    <xs:element name="inkluder" type="inkluderIJournalpost"/>
+                    <xs:element name="inkluder" type="inkluderIJournalpost" maxOccurs="unbounded"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
@@ -237,7 +237,7 @@
         <xs:complexContent>
             <xs:extension base="respons">
                 <xs:sequence>
-                    <xs:element name="inkluder" type="inkluderIDokumentbeskrivelse"/>
+                    <xs:element name="inkluder" type="inkluderIDokumentbeskrivelse" maxOccurs="unbounded"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>


### PR DESCRIPTION
Har splittet ut søkefelt og sorteringfelt til egne lister og refaktorert søk 

[Ref issue #105](https://github.com/ks-no/fiks-arkiv/issues/105). 
Nå skal man kun få mulighet til å sortere og søke felter som henger sammen med typen man søker på. 
Altså at man f.eks. bare får mappe og saksmappe felter som søkefelter hvis man skal søke på saksmappe.

Søk med genererte modeller basert på disse endringene ser slik ut da:
```
           var sok = new Models.V1.Innsyn.Sok.Sok
            {
                Sokdefinisjon = new JournalpostSokdefinisjon()
                {
                    Inkluder = { JournalpostInkluder.Korrespondansepart },
                    Parametere = { 
                        new JournalpostParameter()
                        {
                            Felt = JournalpostSokefelt.RegistreringTittel,
                            Operator = OperatorType.Equal,
                            SokVerdier = new SokVerdier()
                            {
                                Stringvalues = { "En journalpost tittel med wildcard*" }
                            }
                        } 
                    },
                    Sortering =
                    {
                        new JournalpostSortering()
                        {
                            Felt = JournalpostSorteringsfelt.RegistreringOpprettetDato
                        }
                    }
                },
                Take = 10,
                System = "Integrasjonstester",
                Tidspunkt = DateTime.Now,
                MeldingId = Guid.NewGuid().ToString()
            };
```