### PR TITLE
Nytt søkeresultat som inneholder journalpost med saksmappe felter

### DIFF
--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -325,6 +325,40 @@
         </xs:complexContent>
     </xs:complexType>
 
+    <xs:complexType name="journalpostMedSaksmappe">
+        <xs:complexContent>
+            <xs:extension base="registrering">
+                <xs:sequence>
+                    <xs:element name="journalaar" type="n5mdk:journalaar"/>
+                    <xs:element name="journalsekvensnummer" type="n5mdk:journalsekvensnummer"/>
+                    <xs:element name="journalpostnummer" type="n5mdk:journalpostnummer"/>
+                    <xs:element name="journalposttype" type="n5mdk:journalposttype"/>
+                    <xs:element name="journalstatus" type="n5mdk:journalstatus"/>
+                    <xs:element name="journaldato" type="n5mdk:journaldato"/>
+                    <xs:element name="dokumentetsDato" type="n5mdk:dokumentetsDato" minOccurs="0"/>
+                    <xs:element name="mottattDato" type="n5mdk:mottattDato" minOccurs="0"/>
+                    <xs:element name="sendtDato" type="n5mdk:sendtDato" minOccurs="0"/>
+                    <xs:element name="forfallsdato" type="n5mdk:forfallsdato" minOccurs="0"/>
+                    <xs:element name="offentlighetsvurdertDato" type="n5mdk:offentlighetsvurdertDato" minOccurs="0"/>
+                    <xs:element name="antallVedlegg" type="n5mdk:antallVedlegg" minOccurs="0"/>
+                    <xs:element name="utlaantDato" type="n5mdk:utlaantDato" minOccurs="0"/>
+                    <xs:element name="utlaantTil" type="n5mdk:utlaantTil" minOccurs="0"/>
+                    <xs:element name="journalenhet" type="n5mdk:journalenhet" minOccurs="0"/>
+                    <xs:element name="avskrivning" type="avskrivning" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="dokumentflyt" type="dokumentflyt" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="presedens" type="presedens" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="elektroniskSignatur" type="elektroniskSignatur" minOccurs="0"/>
+                    <xs:element name="saksaar" type="n5mdk:saksaar"/>
+                    <xs:element name="sakssekvensnummer" type="n5mdk:sakssekvensnummer"/>
+                    <xs:element name="saksdato" type="n5mdk:saksdato"/>
+                    <xs:element name="administrativEnhet" type="n5mdk:administrativEnhet"/>
+                    <xs:element name="saksansvarlig" type="n5mdk:saksansvarlig"/>
+                    <xs:element name="saksstatus" type="n5mdk:saksstatus"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
     <xs:complexType name="korrespondansepart">
         <xs:sequence>
             <xs:element name="korrespondansepartID" type="n5mdk:korrespondansepartID"/>

--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -327,27 +327,8 @@
 
     <xs:complexType name="journalpostMedSaksmappe">
         <xs:complexContent>
-            <xs:extension base="registrering">
+            <xs:extension base="journalpost">
                 <xs:sequence>
-                    <xs:element name="journalaar" type="n5mdk:journalaar"/>
-                    <xs:element name="journalsekvensnummer" type="n5mdk:journalsekvensnummer"/>
-                    <xs:element name="journalpostnummer" type="n5mdk:journalpostnummer"/>
-                    <xs:element name="journalposttype" type="n5mdk:journalposttype"/>
-                    <xs:element name="journalstatus" type="n5mdk:journalstatus"/>
-                    <xs:element name="journaldato" type="n5mdk:journaldato"/>
-                    <xs:element name="dokumentetsDato" type="n5mdk:dokumentetsDato" minOccurs="0"/>
-                    <xs:element name="mottattDato" type="n5mdk:mottattDato" minOccurs="0"/>
-                    <xs:element name="sendtDato" type="n5mdk:sendtDato" minOccurs="0"/>
-                    <xs:element name="forfallsdato" type="n5mdk:forfallsdato" minOccurs="0"/>
-                    <xs:element name="offentlighetsvurdertDato" type="n5mdk:offentlighetsvurdertDato" minOccurs="0"/>
-                    <xs:element name="antallVedlegg" type="n5mdk:antallVedlegg" minOccurs="0"/>
-                    <xs:element name="utlaantDato" type="n5mdk:utlaantDato" minOccurs="0"/>
-                    <xs:element name="utlaantTil" type="n5mdk:utlaantTil" minOccurs="0"/>
-                    <xs:element name="journalenhet" type="n5mdk:journalenhet" minOccurs="0"/>
-                    <xs:element name="avskrivning" type="avskrivning" minOccurs="0" maxOccurs="unbounded"/>
-                    <xs:element name="dokumentflyt" type="dokumentflyt" minOccurs="0" maxOccurs="unbounded"/>
-                    <xs:element name="presedens" type="presedens" minOccurs="0" maxOccurs="unbounded"/>
-                    <xs:element name="elektroniskSignatur" type="elektroniskSignatur" minOccurs="0"/>
                     <xs:element name="saksaar" type="n5mdk:saksaar"/>
                     <xs:element name="sakssekvensnummer" type="n5mdk:sakssekvensnummer"/>
                     <xs:element name="saksdato" type="n5mdk:saksdato"/>

--- a/Schema/V1/arkivstrukturMinimum.xsd
+++ b/Schema/V1/arkivstrukturMinimum.xsd
@@ -108,15 +108,8 @@
 
     <xs:complexType name="journalpostMedSaksmappeMinimum">
         <xs:complexContent>
-            <xs:extension base="registreringMinimum">
+            <xs:extension base="journalpostMinimum">
                 <xs:sequence>
-                    <xs:element name="journalaar" type="n5mdk:journalaar"/>
-                    <xs:element name="journalsekvensnummer" type="n5mdk:journalsekvensnummer"/>
-                    <xs:element name="journalpostnummer" type="n5mdk:journalpostnummer"/>
-                    <xs:element name="journalposttype" type="n5mdk:journalposttype"/>
-                    <xs:element name="journalstatus" type="n5mdk:journalstatus"/>
-                    <xs:element name="journaldato" type="n5mdk:journaldato"/>
-                    <xs:element name="dokumentetsDato" type="n5mdk:dokumentetsDato" minOccurs="0"/>
                     <xs:element name="saksaar" type="n5mdk:saksaar"/>
                     <xs:element name="sakssekvensnummer" type="n5mdk:sakssekvensnummer"/>
                     <xs:element name="saksdato" type="n5mdk:saksdato"/>

--- a/Schema/V1/arkivstrukturMinimum.xsd
+++ b/Schema/V1/arkivstrukturMinimum.xsd
@@ -106,6 +106,28 @@
         </xs:complexContent>
     </xs:complexType>
 
+    <xs:complexType name="journalpostMedSaksmappeMinimum">
+        <xs:complexContent>
+            <xs:extension base="registreringMinimum">
+                <xs:sequence>
+                    <xs:element name="journalaar" type="n5mdk:journalaar"/>
+                    <xs:element name="journalsekvensnummer" type="n5mdk:journalsekvensnummer"/>
+                    <xs:element name="journalpostnummer" type="n5mdk:journalpostnummer"/>
+                    <xs:element name="journalposttype" type="n5mdk:journalposttype"/>
+                    <xs:element name="journalstatus" type="n5mdk:journalstatus"/>
+                    <xs:element name="journaldato" type="n5mdk:journaldato"/>
+                    <xs:element name="dokumentetsDato" type="n5mdk:dokumentetsDato" minOccurs="0"/>
+                    <xs:element name="saksaar" type="n5mdk:saksaar"/>
+                    <xs:element name="sakssekvensnummer" type="n5mdk:sakssekvensnummer"/>
+                    <xs:element name="saksdato" type="n5mdk:saksdato"/>
+                    <xs:element name="administrativEnhet" type="n5mdk:administrativEnhet"/>
+                    <xs:element name="saksansvarlig" type="n5mdk:saksansvarlig"/>
+                    <xs:element name="saksstatus" type="n5mdk:saksstatus"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
     <xs:complexType name="korrespondansepartMinimum">
         <xs:sequence>
             <xs:element name="korrespondanseparttype" type="n5mdk:korrespondanseparttype"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.resultat.minimum.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.resultat.minimum.xsd
@@ -27,6 +27,7 @@
             <xs:enumeration value="saksmappe"/>
             <xs:enumeration value="registrering"/>
             <xs:enumeration value="journalpost"/>
+            <xs:enumeration value="journalpostMedSaksmappe"/>
             <xs:enumeration value="dokumentbeskrivelse"/>
         </xs:restriction>
     </xs:simpleType>
@@ -43,6 +44,7 @@
             <xs:element name="saksmappe" type="arkivstruktur:saksmappeMinimum"/>
             <xs:element name="registrering" type="arkivstruktur:registreringMinimum"/>
             <xs:element name="journalpost" type="arkivstruktur:journalpostMinimum"/>
+            <xs:element name="journalpostMedSaksmappe" type="arkivstruktur:journalpostMedSaksmappeMinimum"/>
             <xs:element name="dokumentbeskrivelse" type="arkivstruktur:dokumentbeskrivelseMinimum"/>
         </xs:choice>
     </xs:complexType>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.resultat.utvidet.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.resultat.utvidet.xsd
@@ -29,6 +29,7 @@
             <xs:enumeration value="saksmappe"/>
             <xs:enumeration value="registrering"/>
             <xs:enumeration value="journalpost"/>
+            <xs:enumeration value="journalpostMedSaksmappe"/>
             <xs:enumeration value="dokumentbeskrivelse"/>
         </xs:restriction>
     </xs:simpleType>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.resultat.utvidet.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.resultat.utvidet.xsd
@@ -45,6 +45,7 @@
             <xs:element name="saksmappe" type="arkivstruktur:saksmappe"/>
             <xs:element name="registrering" type="arkivstruktur:registrering"/>
             <xs:element name="journalpost" type="arkivstruktur:journalpost"/>
+            <xs:element name="journalpostMedSaksmappe" type="arkivstruktur:journalpostMedSaksmappe"/>
             <xs:element name="dokumentbeskrivelse" type="arkivstruktur:dokumentbeskrivelse"/>
         </xs:choice>
     </xs:complexType>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
@@ -73,6 +73,18 @@
         </xs:complexContent>
     </xs:complexType>
 
+    <xs:complexType name="journalpostMedSaksmappeSokdefinisjon">
+        <xs:complexContent>
+            <xs:extension base="sokdefinisjon">
+                <xs:sequence>
+                    <xs:element name="inkluder" type="journalpostInkluder" maxOccurs="unbounded"/>
+                    <xs:element name="parametere" type="journalpostParameter" maxOccurs="unbounded"/>
+                    <xs:element name="sortering" type="journalpostSortering" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
     <xs:complexType name="dokumentbeskrivelseSokdefinisjon">
         <xs:complexContent>
             <xs:extension base="sokdefinisjon">


### PR DESCRIPTION
Nytt søkeresultat som inneholder journalpost med saksmappe felter. Draft!

Ref [issue 49](https://github.com/ks-no/fiks-arkiv/issues/49)

Kode for å definere et søk på journalpostMedSaksmappe blir seende noenlunde slik ut: 
```
           var sok = new Models.V1.Innsyn.Sok.Sok
            {
                Sokdefinisjon = new JournalpostMedSaksmappeSokdefinisjon()
                {
                    Inkluder = { JournalpostInkluder.Korrespondansepart },
                    Parametere = { 
                        new JournalpostParameter()
                        {
                            Felt = JournalpostSokefelt.RegistreringTittel,
                            Operator = OperatorType.Equal,
                            SokVerdier = new SokVerdier()
                            {
                                Stringvalues = { "En journalpost tittel med wildcard*" }
                            }
                        } 
                    },
                    Sortering =
                    {
                        new JournalpostSortering()
                        {
                            Felt = JournalpostSorteringsfelt.RegistreringOpprettetDato
                        }
                    }
                },
                Take = 10,
                System = "Integrasjonstester",
                Tidspunkt = DateTime.Now,
                MeldingId = Guid.NewGuid().ToString()
            };
```
Bør det være egne sokefelt og sorteringfelter for den nye typen eller blir det likt som for journalpost? 🤔 