### PR TITLE
Oppdatering av registrering skal ha referanseTilRegistrering

### DIFF
--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
@@ -167,7 +167,7 @@
     <xs:complexType name="registreringOppdatering">
         <xs:sequence>
             <xs:element name="referanseTilRegistrering" type="n5mdk:referanseTilRegistrering"/>
-            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel"/>
+            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0"/>
             <xs:element name="partOppdateringer" type="partOppdateringer" minOccurs="0"/>
             <xs:element name="skjerming" type="arkivmelding:skjerming" minOccurs="0"/>
             <xs:element name="gradering" type="arkivmelding:gradering" minOccurs="0"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
@@ -166,10 +166,8 @@
 
     <xs:complexType name="registreringOppdatering">
         <xs:sequence>
-            <xs:choice>
-                <xs:element name="systemID" type="n5mdk:systemID"/>
-                <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel"/>
-            </xs:choice>
+            <xs:element name="referanseTilRegistrering" type="n5mdk:referanseTilRegistrering"/>
+            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel"/>
             <xs:element name="partOppdateringer" type="partOppdateringer" minOccurs="0"/>
             <xs:element name="skjerming" type="arkivmelding:skjerming" minOccurs="0"/>
             <xs:element name="gradering" type="arkivmelding:gradering" minOccurs="0"/>


### PR DESCRIPTION
Oppdatering av registrering skal ha referanseTilRegistrering og mulighet for å endre referanseEksternNoekkel tilsvarende som mappe

Dette ser ut til å bare ha blitt glemt når vi gjorde det for mappe oppdatering. Oppdaget ved oppdatering av integrasjonstester og eksempelkode.