### PR TITLE
Rydding i referanseForelderMappe felter

### DIFF
--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -165,7 +165,7 @@
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID"/>
             <xs:element name="mappeID" type="n5mdk:mappeID"/>
-            <xs:element name="ReferanseForeldermappe" type="n5mdk:referanseTilMappe" minOccurs="0"/>
+            <xs:element name="referanseForeldermappe" type="n5mdk:referanseTilMappe" minOccurs="0"/>
             <xs:element name="tittel" type="n5mdk:tittel"/>
             <xs:element name="offentligTittel" type="n5mdk:offentligTittel" minOccurs="0"/>
             <xs:element name="beskrivelse" type="n5mdk:beskrivelse" minOccurs="0"/>

--- a/Schema/V1/arkivstrukturNoekler.xsd
+++ b/Schema/V1/arkivstrukturNoekler.xsd
@@ -18,7 +18,7 @@
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
             <xs:element name="mappeID" type="n5mdk:mappeID" minOccurs="0"/>
-            <xs:element minOccurs="0" name="ReferanseForeldermappe" type="n5mdk:systemID"/>
+            <xs:element name="referanseForeldermappe" type="n5mdk:referanseTilMappe" minOccurs="0"/>
             <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0"/>
             <xs:choice>
                 <xs:element name="mappe" type="mappeNoekler" minOccurs="0" maxOccurs="unbounded"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.kvittering.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.kvittering.xsd
@@ -2,13 +2,10 @@
 <xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmeldingkvittering/v1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:n5mdk="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
-           xmlns:arkivstruktur="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
            targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmeldingkvittering/v1"
            elementFormDefault="qualified">
     <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
                schemaLocation="./metadatakatalog.xsd"/>
-    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
-               schemaLocation="./arkivstruktur.xsd"/>
 
     <xs:element name="arkivmeldingKvittering" type="arkivmeldingKvittering"/>
 
@@ -29,7 +26,7 @@
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID"/>
             <xs:element name="mappeID" type="n5mdk:mappeID" minOccurs="0"/>
-            <xs:element minOccurs="0" name="ReferanseForeldermappe" type="n5mdk:systemID"/>
+            <xs:element name="referanseForeldermappe" type="n5mdk:referanseTilMappe" minOccurs="0"/>
             <xs:element name="opprettetDato" type="n5mdk:opprettetDato" minOccurs="0"/>
             <xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
             <xs:element name="avsluttetDato" type="n5mdk:avsluttetDato" minOccurs="0"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.xsd
@@ -27,7 +27,7 @@
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
             <xs:element name="mappeID" type="n5mdk:mappeID" minOccurs="0"/>
-            <xs:element name="referanseForeldermappe" type="referanseForelderMappe" minOccurs="0"/>
+            <xs:element name="referanseForeldermappe" type="referanseTilMappe" minOccurs="0"/>
             <xs:element name="tittel" type="n5mdk:tittel"/>
             <xs:element name="offentligTittel" type="n5mdk:offentligTittel" minOccurs="0"/>
             <xs:element name="beskrivelse" type="n5mdk:beskrivelse" minOccurs="0"/>
@@ -125,7 +125,7 @@
             <xs:element name="arkivertAv" type="n5mdk:arkivertAv" minOccurs="0"/>
             <!-- Dersom en registrering kommer alene må den kunne plasseres i en mappe eller arkivdel-->
             <xs:choice minOccurs="0">
-                <xs:element name="referanseForelderMappe" type="referanseForelderMappe"/>
+                <xs:element name="referanseForelderMappe" type="referanseTilMappe"/>
                 <xs:element name="arkivdel" type="n5mdk:kode"/>
             </xs:choice>
             <xs:element name="part" type="part" minOccurs="0" maxOccurs="unbounded"/>
@@ -363,11 +363,11 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:complexType name="referanseForelderMappe">
+    <xs:complexType name="referanseTilMappe">
         <xs:choice>
             <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
-            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0"/>
             <xs:element name="saksnummer" type="n5mdk:saksnummer" minOccurs="0"/>
+            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0"/>
         </xs:choice>
     </xs:complexType>
 

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.mappe.hent.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.mappe.hent.xsd
@@ -3,13 +3,10 @@
 <xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/mappe/hent/v1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:n5mdk="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
-           xmlns:arkivstruktur="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
            targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/mappe/hent/v1"
            elementFormDefault="qualified">
     <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
                schemaLocation="./metadatakatalog.xsd"/>
-    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
-               schemaLocation="./arkivstruktur.xsd"/>
 
     <xs:element name="mappeHent" type="mappeHent"/>
 

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.registrering.hent.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.registrering.hent.xsd
@@ -2,13 +2,10 @@
 <xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/registrering/hent/v1"
 			xmlns:xs="http://www.w3.org/2001/XMLSchema"
 			xmlns:n5mdk="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
-		  	xmlns:arkivstruktur="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
 			targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/registrering/hent/v1"
 			elementFormDefault="qualified">
 	<xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
 		schemaLocation="./metadatakatalog.xsd"/>
-	<xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivstruktur/v1"
-			   schemaLocation="./arkivstruktur.xsd"/>
 
 	<xs:element name="registreringHent" type="registreringHent"/>
 	


### PR DESCRIPTION
Rydding i flere referanseForelderMappe felter.

Sørget for at det er alltid liten forbokstav i alle steder man har elementet referanseForelderMappe og endret til typen referanseTilMappe steder det fremdeles var systemID. Det skal vel alltid være referanseTilMappe typen. Endret også navnet på complexTypen i arkivmelding til å hete referanseTilMappe i arkivmelding for å ha en bedre "consistency". 
Kunne også ta bort referansen til arkivstruktur.xsd i 2 xsd'er.