### PR TITLE
Tatt bort meldingId og svarPaMeldingId

### DIFF
--- a/Schema/V1/metadatakatalog.xsd
+++ b/Schema/V1/metadatakatalog.xsd
@@ -594,10 +594,10 @@
   <xs:complexType name="referanseTilJournalpost">
     <xs:sequence>
       <xs:element name="systemID" type="systemID" minOccurs="0"/>
+      <xs:element name="registreringsID" type="registreringsID" minOccurs="0"/>
       <xs:element name="journalnummer" type="journalnummer" minOccurs="0"/>
       <xs:element name="saksJournalpostnummer" type="saksJournalpostnummer" minOccurs="0"/>
       <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="registreringsID" type="registreringsID" minOccurs="0"/>
     </xs:sequence>
   </xs:complexType>
 

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.kvittering.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.kvittering.xsd
@@ -12,7 +12,6 @@
     <xs:complexType name="arkivmeldingKvittering">
         <xs:sequence>
             <xs:element name="system" type="xs:string"/>
-            <xs:element name="meldingId" type="xs:string"/>
             <xs:element name="tidspunkt" type="xs:dateTime"/>
             <xs:choice>
                 <xs:element name="mappeKvittering" type="mappeKvittering" minOccurs="0" maxOccurs="unbounded"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
@@ -12,7 +12,6 @@
 
     <xs:complexType name="arkivmeldingOppdatering">
         <xs:sequence>
-            <xs:element name="meldingId" type="xs:string"/>
             <xs:element name="tidspunkt" type="xs:dateTime"/>
             <xs:choice minOccurs="1" maxOccurs="1">
                 <xs:element name="mappeOppdateringer" type="mappeOppdatering" minOccurs="0" maxOccurs="unbounded"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.xsd
@@ -13,7 +13,6 @@
     <xs:complexType name="arkivmelding">
         <xs:sequence>
             <xs:element name="system" type="xs:string"/>
-            <xs:element name="meldingId" type="xs:string"/>
             <xs:element name="tidspunkt" type="xs:dateTime"/>
             <xs:element name="antallFiler" type="xs:int"/>
             <xs:choice>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.resultat.minimum.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.resultat.minimum.xsd
@@ -10,8 +10,6 @@
     <xs:complexType name="sokeresultatMinimum">
         <xs:sequence>
             <xs:element name="system" type="xs:string"/>
-            <xs:element name="meldingId" type="xs:string"/>
-            <xs:element name="svarPaMeldingId" type="xs:string"/>
             <xs:element name="tidspunkt" type="xs:dateTime"/>
             <xs:element name="take" type="xs:int"/>
             <xs:element name="skip" type="xs:int"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.resultat.noekler.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.resultat.noekler.xsd
@@ -10,8 +10,6 @@
     <xs:complexType name="sokeresultatNoekler">
         <xs:sequence>
             <xs:element name="system" type="xs:string"/>
-            <xs:element name="meldingId" type="xs:string"/>
-            <xs:element name="svarPaMeldingId" type="xs:string"/>
             <xs:element name="tidspunkt" type="xs:dateTime"/>
             <xs:element name="take" type="xs:int"/>
             <xs:element name="skip" type="xs:int"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.resultat.utvidet.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.resultat.utvidet.xsd
@@ -12,8 +12,6 @@
     <xs:complexType name="sokeresultat">
         <xs:sequence>
             <xs:element name="system" type="xs:string"/>
-            <xs:element name="meldingId" type="xs:string"/>
-            <xs:element name="svarPaMeldingId" type="xs:string"/>
             <xs:element name="tidspunkt" type="xs:dateTime"/>
             <xs:element name="take" type="xs:int"/>
             <xs:element name="skip" type="xs:int"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
@@ -14,7 +14,6 @@
     <xs:complexType name="sok">
         <xs:sequence>
             <xs:element name="system" type="xs:string"/>
-            <xs:element name="meldingId" type="xs:string"/>
             <xs:element name="tidspunkt" type="xs:dateTime"/>
             <xs:element name="take" type="xs:int"/>
             <xs:element name="skip" type="xs:int"/>


### PR DESCRIPTION
Tatt bort meldingId og svarPaMeldingId da disse kommer med som headere i Fiks-IO meldingene

Ref issue #[115](https://github.com/ks-no/fiks-arkiv/issues/115)