### PR TITLE
Fikset feil identifikator type for sletting av kryssreferanse

### DIFF
--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
@@ -90,7 +90,7 @@
     
     <xs:complexType name="kryssreferanseSlett">
         <xs:sequence>
-            <xs:element name="systemID" type="n5mdk:systemID"/>
+            <xs:element name="kryssreferanseID" type="n5mdk:kryssreferanseID"/>
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
Det var systemID som identifikator for sletting av kryssreferanse. Men det ser ikke ut til å være korrekt mtp at oppdatering av kryssreferanse bruker kryssreferanseID som identifikator?