### PR TITLE
Lagt på dokumentnummer og versjonsnummer i kvittering

### DIFF
--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.kvittering.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.kvittering.xsd
@@ -101,6 +101,7 @@
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID"/>
             <xs:element name="versjonsnummer" type="n5mdk:versjonsnummer" minOccurs="0"/>
+            <xs:element name="variantformat" type="n5mdk:variantformat" minOccurs="0"/>
             <xs:element name="opprettetDato" type="n5mdk:opprettetDato" minOccurs="0"/>
             <xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
         </xs:sequence>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.kvittering.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.kvittering.xsd
@@ -92,6 +92,7 @@
             <xs:element name="systemID" type="n5mdk:systemID"/>
             <xs:element name="opprettetDato" type="n5mdk:opprettetDato" minOccurs="0"/>
             <xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
+            <xs:element name="dokumentnummer" type="n5mdk:dokumentnummer" minOccurs="0"/>
             <xs:element name="dokumentobjekt" type="dokumentobjektKvittering" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
@@ -99,6 +100,7 @@
     <xs:complexType name="dokumentobjektKvittering">
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID"/>
+            <xs:element name="versjonsnummer" type="n5mdk:versjonsnummer" minOccurs="0"/>
             <xs:element name="opprettetDato" type="n5mdk:opprettetDato" minOccurs="0"/>
             <xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
         </xs:sequence>


### PR DESCRIPTION
Ref #165 

Forslaget var at vi legger på `dokumentnummer` slik at vi ser hvilken `dokumentbeskrivelseKvittering` som henger sammen med hvilken `dokumentbeskrivelse` i opprett-melding.

Men bør det ikke også gjøres liknende for `dokumentobjekt` sitt felt, `versjonsnummer`? Siden det er mulig å opprette flere dokumentobjekter på en dokumentbeskrivelse?