### PR TITLE
Manglet m-kode i description på noen felter i metadatakatalog

### DIFF
--- a/Schema/V1/metadatakatalog.xsd
+++ b/Schema/V1/metadatakatalog.xsd
@@ -579,29 +579,6 @@
     </xs:sequence>
   </xs:complexType>
 
-  <xs:complexType name="referanseTilJournalpost">
-    <xs:annotation>
-      <xs:documentation>Endret (fiks-arkiv):  nytt felt som inneholder forskjellige id'er som kan identifisere en journalpost</xs:documentation>
-    </xs:annotation>
-    <xs:sequence>
-      <xs:element name="systemID" type="systemID" minOccurs="0"/>
-      <xs:element name="registreringsID" type="registreringsID" minOccurs="0"/>
-      <xs:element name="journalnummer" type="journalnummer" minOccurs="0"/>
-      <xs:element name="saksJournalpostnummer" type="saksJournalpostnummer" minOccurs="0"/>
-      <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0" maxOccurs="1"/>
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="referanseTilKlassifikasjon">
-    <xs:annotation>
-      <xs:documentation>Endret (fiks-arkiv):  nytt felt som inneholder forskjellige id'er som kan identifisere en klassifikasjon</xs:documentation>
-    </xs:annotation>
-    <xs:sequence>
-      <xs:element name="klassifikasjonssystemID" type="klassifikasjonssystemID"/>
-      <xs:element name="klasseID" type="klasseID"/>
-    </xs:sequence>
-  </xs:complexType>
-
   <xs:simpleType name="referanseAvskrivesAvJournalpost">
     <xs:annotation>
       <xs:documentation>M215</xs:documentation>
@@ -663,6 +640,31 @@
     </xs:annotation>
     <xs:sequence>
       <xs:element name="systemID" type="systemID" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="referanseTilKlassifikasjon">
+    <xs:annotation>
+      <xs:documentation>M226</xs:documentation>
+      <xs:documentation>Endret (fiks-arkiv):  nytt felt som inneholder forskjellige id'er som kan identifisere en klassifikasjon</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="klassifikasjonssystemID" type="klassifikasjonssystemID"/>
+      <xs:element name="klasseID" type="klasseID"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="referanseTilJournalpost">
+    <xs:annotation>
+      <xs:documentation>M227</xs:documentation>
+      <xs:documentation>Endret (fiks-arkiv):  nytt felt som inneholder forskjellige id'er som kan identifisere en journalpost</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="systemID" type="systemID" minOccurs="0"/>
+      <xs:element name="registreringsID" type="registreringsID" minOccurs="0"/>
+      <xs:element name="journalnummer" type="journalnummer" minOccurs="0"/>
+      <xs:element name="saksJournalpostnummer" type="saksJournalpostnummer" minOccurs="0"/>
+      <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:complexType>
 


### PR DESCRIPTION
Disse kodene er for å lett kunne slå opp i dokumentasjon som da har samme id