### PR TITLE
Endret koordinatsystem til datatypen kode

### DIFF
--- a/Schema/V1/metadatakatalog.xsd
+++ b/Schema/V1/metadatakatalog.xsd
@@ -911,15 +911,16 @@
     <xs:restriction base="xs:double" />
   </xs:simpleType>
 
-  <xs:simpleType name="koordinatsystem">
+  <xs:complexType name="koordinatsystem">
     <xs:annotation>
       <xs:documentation>M327</xs:documentation>
-      <xs:documentation>Opprettet: GI Arkiv 2.0</xs:documentation>
+      <xs:documentation>Opprettet: GI Arkiv 2.0. Datatype kode</xs:documentation>
+      <xs:documentation>Kodeliste (kode:beskrivelse) = "EPSG:25832":"EUREF89 UTM sone 32", "EPSG:25833":"EUREF89 UTM sone 33", "EPSG:25835":"EUREF89 UTM sone 35", "EPSG:4258":"EUREF 89 Geografisk (ETRS 89) 2d"</xs:documentation>
     </xs:annotation>
-    <xs:restriction base="xs:string">
-      <xs:minLength value="1"/>
-    </xs:restriction>
-  </xs:simpleType>
+    <xs:complexContent>
+      <xs:extension base="kode"/>
+    </xs:complexContent>
+  </xs:complexType>
 
   <!-- M370-M399: Møtebehandling -->
 


### PR DESCRIPTION
Endret koordinatsystem til datatypen kode som da vil være de 4 samme som for Fiks Plan.
Er det ok at datatypen punkt ser slikt ut eller bør den være 100% lik som Fiks Plan?
```
<xs:complexType name="punkt">
        <xs:sequence>
            <xs:element name="koordinatsystem" type="n5mdk:koordinatsystem"/>
            <xs:element name="x" type="n5mdk:x"/>
            <xs:element name="y" type="n5mdk:y"/>
            <xs:element name="z" type="n5mdk:z" minOccurs="0"/>
        </xs:sequence>
    </xs:complexType>
```