### PR TITLE
Lagt til spraak felt på hent og søk meldinger

### DIFF
--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.mappe.hent.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.mappe.hent.xsd
@@ -18,10 +18,16 @@
     <xs:element name="mappeHent" type="mappeHent"/>
 
     <xs:complexType name="mappeHent">
+        <xs:annotation>
+            <xs:documentation>
+                The optional "spraak" value must be a ISO 639-1 code. If "spraak" is not set, default language is a configuration choice in the archive.
+            </xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="system" type="xs:string"/>
             <xs:element name="referanseTilMappe" type="n5mdk:referanseTilMappe"/>
             <xs:element name="inkluder" type="inkluder" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="spraak" type="xs:string" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.registrering.hent.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.registrering.hent.xsd
@@ -17,10 +17,16 @@
 	<xs:element name="registreringHent" type="registreringHent"/>
 
 	<xs:complexType name="registreringHent">
+		<xs:annotation>
+			<xs:documentation>
+				The optional "spraak" value must be a ISO 639-1 code. If "spraak" is not set, default language is a configuration choice in the archive.
+			</xs:documentation>
+		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="system" type="xs:string"/>
 			<xs:element name="referanseTilRegistrering" type="n5mdk:referanseTilRegistrering"/>
 			<xs:element name="inkluder" type="inkluder" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="spraak" type="xs:string" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
 

--- a/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.innsyn.sok.xsd
@@ -20,11 +20,17 @@
     <xs:element name="sok" type="sok"/>
 
     <xs:complexType name="sok">
+        <xs:annotation>
+            <xs:documentation>
+                The optional "spraak" value must be a ISO 639-1 code. If "spraak" is not set, default language is a configuration choice in the archive. 
+            </xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="system" type="xs:string"/>
             <xs:element name="take" type="xs:int"/>
             <xs:element name="skip" type="xs:int"/>
             <xs:element name="sokdefinisjon" type="sokdefinisjon"/>
+            <xs:element name="spraak" type="xs:string" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
Ref issue #188 
Lagt til spraak felt med dokumentasjon som viser til at man må følge ISO 639-1 koder.