### PR TITLE
Mappe og registrering kan arkiveres sammen

### DIFF
--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.kvittering.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.kvittering.xsd
@@ -20,8 +20,7 @@
     <xs:complexType name="arkivmeldingKvittering">
         <xs:sequence>
             <xs:choice>
-                <xs:element name="nyMappeKvittering" type="nyMappeKvittering" minOccurs="0" />
-                <xs:element name="eksisterendeMappeKvittering" type="eksisterendeMappeKvittering" minOccurs="0" />
+                <xs:element name="mappeKvittering" type="mappeKvittering" minOccurs="0" />
                 <xs:element name="mappeFeilet" type="feilmelding:feilmeldingBase" minOccurs="0" />
             </xs:choice>
             <xs:choice>
@@ -41,21 +40,8 @@
             <xs:element name="avsluttetDato" type="n5mdk:avsluttetDato" minOccurs="0"/>
             <xs:element name="avsluttetAv" type="n5mdk:avsluttetAv" minOccurs="0"/>
             <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0"/>
+            <xs:element name="opprettetEllerEksisterende" type="opprettetEllerEksisterende" />
         </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="eksisterendeMappeKvittering">
-        <xs:complexContent>
-            <xs:extension base="mappeKvittering">
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
-    <xs:complexType name="nyMappeKvittering">
-        <xs:complexContent>
-            <xs:extension base="mappeKvittering">
-            </xs:extension>
-        </xs:complexContent>
     </xs:complexType>
 
     <xs:complexType name="saksmappeKvittering">
@@ -66,20 +52,6 @@
                     <xs:element name="sakssekvensnummer" type="n5mdk:sakssekvensnummer" minOccurs="0"/>
                     <xs:element name="saksdato" type="n5mdk:saksdato" minOccurs="0"/>
                 </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
-    <xs:complexType name="eksisterendeSaksmappeKvittering">
-        <xs:complexContent>
-            <xs:extension base="saksmappeKvittering">
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-    
-    <xs:complexType name="nySaksmappeKvittering">
-        <xs:complexContent>
-            <xs:extension base="mappeKvittering">
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -133,5 +105,12 @@
             <xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
+
+    <xs:simpleType name="opprettetEllerEksisterende" final="restriction" >
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Opprettet" />
+            <xs:enumeration value="Eksisterende" />
+        </xs:restriction>
+    </xs:simpleType>
 
 </xs:schema>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.kvittering.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.kvittering.xsd
@@ -19,9 +19,13 @@
     <xs:complexType name="arkivmeldingKvittering">
         <xs:sequence>
             <xs:choice>
-                <xs:element name="mappeKvittering" type="mappeKvittering" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element name="registreringKvittering" type="registreringKvittering" minOccurs="0"
-                            maxOccurs="unbounded"/>
+                <xs:element name="nyMappeKvittering" type="nyMappeKvittering" minOccurs="0" />
+                <xs:element name="eksisterendeMappeKvittering" type="eksisterendeMappeKvittering" minOccurs="0" />
+                <xs:element name="mappeFeilet" type="arkiveringFeilet" minOccurs="0" />
+            </xs:choice>
+            <xs:choice>
+                <xs:element name="registreringKvittering" type="registreringKvittering" minOccurs="0" />
+                <xs:element name="registreringFeilet" type="arkiveringFeilet" minOccurs="0" />
             </xs:choice>
         </xs:sequence>
     </xs:complexType>
@@ -36,12 +40,21 @@
             <xs:element name="avsluttetDato" type="n5mdk:avsluttetDato" minOccurs="0"/>
             <xs:element name="avsluttetAv" type="n5mdk:avsluttetAv" minOccurs="0"/>
             <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0"/>
-            <xs:choice>
-                <xs:element name="mappeKvittering" type="mappeKvittering" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element name="registreringKvittering" type="registreringKvittering" minOccurs="0"
-                            maxOccurs="unbounded"/>
-            </xs:choice>
         </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="eksisterendeMappeKvittering">
+        <xs:complexContent>
+            <xs:extension base="mappeKvittering">
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="nyMappeKvittering">
+        <xs:complexContent>
+            <xs:extension base="mappeKvittering">
+            </xs:extension>
+        </xs:complexContent>
     </xs:complexType>
 
     <xs:complexType name="saksmappeKvittering">
@@ -52,6 +65,20 @@
                     <xs:element name="sakssekvensnummer" type="n5mdk:sakssekvensnummer" minOccurs="0"/>
                     <xs:element name="saksdato" type="n5mdk:saksdato" minOccurs="0"/>
                 </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="eksisterendeSaksmappeKvittering">
+        <xs:complexContent>
+            <xs:extension base="saksmappeKvittering">
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    
+    <xs:complexType name="nySaksmappeKvittering">
+        <xs:complexContent>
+            <xs:extension base="mappeKvittering">
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -103,6 +130,12 @@
             <xs:element name="variantformat" type="n5mdk:variantformat" minOccurs="0"/>
             <xs:element name="opprettetDato" type="n5mdk:opprettetDato" minOccurs="0"/>
             <xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="arkiveringFeilet">
+        <xs:sequence>
+            <xs:element name="feilmelding" type="xs:string"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.kvittering.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.kvittering.xsd
@@ -2,10 +2,11 @@
 <xs:schema xmlns="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmelding/opprett/kvittering/v1"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:n5mdk="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
+           xmlns:feilmelding="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/feil/feilmelding/v1"
            targetNamespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/arkivmelding/opprett/kvittering/v1"
            elementFormDefault="qualified">
-    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1"
-               schemaLocation="./metadatakatalog.xsd"/>
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/metadatakatalog/v1" schemaLocation="./metadatakatalog.xsd"/>
+    <xs:import namespace="https://ks-no.github.io/standarder/fiks-protokoll/fiks-arkiv/feil/feilmelding/v1" schemaLocation="./feilmeldingBase.xsd"/>
     
     <xs:annotation>
         <xs:documentation>
@@ -21,11 +22,11 @@
             <xs:choice>
                 <xs:element name="nyMappeKvittering" type="nyMappeKvittering" minOccurs="0" />
                 <xs:element name="eksisterendeMappeKvittering" type="eksisterendeMappeKvittering" minOccurs="0" />
-                <xs:element name="mappeFeilet" type="arkiveringFeilet" minOccurs="0" />
+                <xs:element name="mappeFeilet" type="feilmelding:feilmeldingBase" minOccurs="0" />
             </xs:choice>
             <xs:choice>
                 <xs:element name="registreringKvittering" type="registreringKvittering" minOccurs="0" />
-                <xs:element name="registreringFeilet" type="arkiveringFeilet" minOccurs="0" />
+                <xs:element name="registreringFeilet" type="feilmelding:feilmeldingBase" minOccurs="0" />
             </xs:choice>
         </xs:sequence>
     </xs:complexType>
@@ -130,12 +131,6 @@
             <xs:element name="variantformat" type="n5mdk:variantformat" minOccurs="0"/>
             <xs:element name="opprettetDato" type="n5mdk:opprettetDato" minOccurs="0"/>
             <xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="arkiveringFeilet">
-        <xs:sequence>
-            <xs:element name="feilmelding" type="xs:string"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
@@ -9,7 +9,8 @@
     
     <xs:annotation>
         <xs:documentation>
-            This is connected to the 'no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett' message. Use this messagetype for create.
+            This is connected to the 'no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett' message. Use this messagetype for create objects.
+            Create either a "mappe", "registrering" or both. When creating both the "registrering" needs to be connected to the "mappe"  
         </xs:documentation>
     </xs:annotation>
     
@@ -20,10 +21,8 @@
             <xs:element name="system" type="xs:string"/>
             <xs:element name="regel" type="xs:string" minOccurs="0"/>
             <xs:element name="antallFiler" type="xs:int"/>
-            <xs:choice>
-                <xs:element name="mappe" type="mappe" minOccurs="0"/>
-                <xs:element name="registrering" type="registrering" minOccurs="0"/>
-            </xs:choice>
+            <xs:element name="mappe" type="mappe" minOccurs="0"/>
+            <xs:element name="registrering" type="registrering" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
Ref issue #187 
Man kan nå sende arkivmelding med mappe og registrering sammen.
Hvis man sender inn en mappe som eksisterer så vil den ikke opprettes men man får en kvittering som indikerer at den ble ikke opprettet, men får allikevel info om mappen tilbake. 
Feiler noe får man egen feilmeldingstype tilbake i kvitteringen.
F.eks. hvis det var noe feil i mappe metadata så får man feil der og ingenting ble opprettet, heller ikke klarte man å se om det eksisterte fra før.