### PR TITLE
Endret fra land til landkode

### DIFF
--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -231,7 +231,7 @@
             <xs:element name="postadresse" type="n5mdk:postadresse" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="postnummer" type="n5mdk:postnummer" minOccurs="0"/>
             <xs:element name="poststed" type="n5mdk:poststed" minOccurs="0"/>
-            <xs:element name="land" type="n5mdk:land" minOccurs="0"/>
+            <xs:element name="landkode" type="n5mdk:landkode" minOccurs="0"/>
             <xs:element name="epostadresse" type="n5mdk:epostadresse" minOccurs="0"/>
             <xs:element name="telefonnummer" type="n5mdk:telefonnummer" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="kontaktperson" type="n5mdk:kontaktperson" minOccurs="0"/>
@@ -396,7 +396,7 @@
             <xs:element name="postadresse" type="n5mdk:postadresse" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="postnummer" type="n5mdk:postnummer" minOccurs="0"/>
             <xs:element name="poststed" type="n5mdk:poststed" minOccurs="0"/>
-            <xs:element name="land" type="n5mdk:land" minOccurs="0"/>
+            <xs:element name="landkode" type="n5mdk:landkode" minOccurs="0"/>
             <xs:element name="epostadresse" type="n5mdk:epostadresse" minOccurs="0"/>
             <xs:element name="telefonnummer" type="n5mdk:telefonnummer" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="kontaktperson" type="n5mdk:kontaktperson" minOccurs="0"/>

--- a/Schema/V1/metadatakatalog.xsd
+++ b/Schema/V1/metadatakatalog.xsd
@@ -867,15 +867,16 @@
     </xs:restriction>
   </xs:simpleType>
 
-  <xs:simpleType name="landkode">
+  <xs:complexType name="landkode">
     <xs:annotation>
       <xs:documentation>M322</xs:documentation>
       <xs:documentation>Opprettet: GI Arkiv 2.0</xs:documentation>
+      <xs:documentation>Endret: Fiks Arkiv 1.0 endret til å være et kode objekt</xs:documentation>
     </xs:annotation>
-    <xs:restriction base="xs:string">
-      <xs:minLength value="1"/>
-    </xs:restriction>
-  </xs:simpleType>
+    <xs:complexContent>
+      <xs:extension base="kode"/>
+    </xs:complexContent>
+  </xs:complexType>
 
   <xs:simpleType name="planidentifikasjon">
     <xs:annotation>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
@@ -156,7 +156,7 @@
             <xs:element name="postadresse" type="n5mdk:postadresse" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="postnummer" type="n5mdk:postnummer" minOccurs="0"/>
             <xs:element name="poststed" type="n5mdk:poststed" minOccurs="0"/>
-            <xs:element name="land" type="n5mdk:land" minOccurs="0"/>
+            <xs:element name="landkode" type="n5mdk:landkode" minOccurs="0"/>
             <xs:element name="epostadresse" type="n5mdk:epostadresse" minOccurs="0"/>
             <xs:element name="telefonnummer" type="n5mdk:telefonnummer" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="kontaktperson" type="n5mdk:kontaktperson" minOccurs="0"/>
@@ -237,7 +237,7 @@
             <xs:element name="postadresse" type="n5mdk:postadresse" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="postnummer" type="n5mdk:postnummer" minOccurs="0"/>
             <xs:element name="poststed" type="n5mdk:poststed" minOccurs="0"/>
-            <xs:element name="land" type="n5mdk:land" minOccurs="0"/>
+            <xs:element name="landkode" type="n5mdk:landkode" minOccurs="0"/>
             <xs:element name="epostadresse" type="n5mdk:epostadresse" minOccurs="0"/>
             <xs:element name="telefonnummer" type="n5mdk:telefonnummer" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="kontaktperson" type="n5mdk:kontaktperson" minOccurs="0"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
@@ -209,7 +209,7 @@
             <xs:element name="postadresse" type="n5mdk:postadresse" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="postnummer" type="n5mdk:postnummer" minOccurs="0"/>
             <xs:element name="poststed" type="n5mdk:poststed" minOccurs="0"/>
-            <xs:element name="land" type="n5mdk:land" minOccurs="0"/>
+            <xs:element name="landkode" type="n5mdk:landkode" minOccurs="0"/>
             <xs:element name="epostadresse" type="n5mdk:epostadresse" minOccurs="0"/>
             <xs:element name="telefonnummer" type="n5mdk:telefonnummer" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="kontaktperson" type="n5mdk:kontaktperson" minOccurs="0"/>
@@ -236,7 +236,7 @@
             <xs:element name="postadresse" type="n5mdk:postadresse" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="postnummer" type="n5mdk:postnummer" minOccurs="0"/>
             <xs:element name="poststed" type="n5mdk:poststed" minOccurs="0"/>
-            <xs:element name="land" type="n5mdk:land" minOccurs="0"/>
+            <xs:element name="landkode" type="n5mdk:landkode" minOccurs="0"/>
             <xs:element name="epostadresse" type="n5mdk:epostadresse" minOccurs="0"/>
             <xs:element name="telefonnummer" type="n5mdk:telefonnummer" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="kontaktperson" type="n5mdk:kontaktperson" minOccurs="0"/>


### PR DESCRIPTION
Endret alle steder det var datatypen `land` til nå `landkode`. Da er `land` navn på land, f.eks. "Sverige" og `landkode` tilhørende landkode "SE".
Men trenger man begge deler? Jeg tenker det holder med landkode da man kan finne ut av navnet på mottakende side? 
Landkode må være det som er styrende.

Vi endrer også landkode i metadatakatalog til å bli et kode objekt

Ref issue #206 

**Denne endringen er breaking for meldingstypene:**
- Opprett Arkivmelding - `no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett`
- Oppdater Arkivmelding -  `no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater`
- Hent meldinger for objekter som brukte `land` som nå blir `landkode`. F.eks. korrespondansepart objektet

Med breaking change så menes at man må gjøre kodeendring for å bygge melding og lese melding etter endring.
Det betyr også at man må endre i klient og arkivsystem samtidig, eller så vil ikke melding kunne leses av mottaker.