### PR TITLE
Korrigert filnavn og referanseDokumentfil kommentar 

### DIFF
--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -488,7 +488,7 @@
             <xs:element name="opprettetAv" type="n5mdk:opprettetAv"/>
             <xs:element name="referanseDokumentfil" type="n5mdk:referanseDokumentfil">
                 <xs:annotation>
-                    <xs:documentation>Dette er enten filnavn slik filen heter i meldingen eller URL som kan brukes for å hente filen. Vil normalt ikke inneholde tegn som komma, æøå etc. som gjerne er med i filnavn. Dette filnavnet vil kunne være forskjellig fra "filnavn" attributtet i ekelte tilfeller, f.eks. hvor meldingen inneholder flere filer med samme navn.</xs:documentation>
+                    <xs:documentation>Dette er enten filnavn slik filen heter i meldingen eller URL som kan brukes for å hente filen. Vil normalt ikke inneholde tegn som komma, æøå etc. som gjerne er med i filnavn. Dette filnavnet vil kunne være forskjellig fra "filnavn" attributtet i enkelte tilfeller, f.eks. hvor meldingen inneholder flere filer med samme navn.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="sjekksum" type="n5mdk:sjekksum"/>

--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -476,13 +476,21 @@
             <xs:element name="systemID" type="n5mdk:systemID"/>
             <xs:element name="versjonsnummer" type="n5mdk:versjonsnummer"/>
             <xs:element name="variantformat" type="n5mdk:variantformat"/>
-            <xs:element name="filnavn" type="xs:string"/>
+            <xs:element name="filnavn" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>Det opprinnelige filnavnet som gjerne skal brukes hvis filen lastes ned. Kan inneholde alle lovlige tegn for filnavn. Egnet også for visning.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="format" type="n5mdk:format"/>
             <xs:element name="mimeType" type="xs:string" minOccurs="0"/>
             <xs:element name="formatDetaljer" type="n5mdk:formatDetaljer" minOccurs="0"/>
             <xs:element name="opprettetDato" type="n5mdk:opprettetDato"/>
             <xs:element name="opprettetAv" type="n5mdk:opprettetAv"/>
-            <xs:element name="referanseDokumentfil" type="n5mdk:referanseDokumentfil"/>
+            <xs:element name="referanseDokumentfil" type="n5mdk:referanseDokumentfil">
+                <xs:annotation>
+                    <xs:documentation>Dette er enten filnavn slik filen heter i meldingen eller URL som kan brukes for å hente filen. Vil normalt ikke inneholde tegn som komma, æøå etc. som gjerne er med i filnavn. Dette filnavnet vil kunne være forskjellig fra "filnavn" attributtet i ekelte tilfeller, f.eks. hvor meldingen inneholder flere filer med samme navn.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="sjekksum" type="n5mdk:sjekksum"/>
             <xs:element name="sjekksumAlgoritme" type="n5mdk:sjekksumAlgoritme"/>
             <xs:element name="filstoerrelse" type="n5mdk:filstoerrelse"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
@@ -188,7 +188,7 @@
             </xs:element>
             <xs:element name="referanseDokumentfil" type="n5mdk:referanseDokumentfil" minOccurs="0">
                 <xs:annotation>
-                    <xs:documentation>URL som kan brukes for å hente filen. Vil normalt ikke inneholde tegn som komma, æøå etc. som gjerne er med i filnavn.</xs:documentation>
+                    <xs:documentation>Dette er enten filnavn slik filen heter i meldingen eller URL som kan brukes for å hente filen. Vil normalt ikke inneholde tegn som komma, æøå etc. som gjerne er med i filnavn. Dette filnavnet vil kunne være forskjellig fra "filnavn" attributtet i ekelte tilfeller, f.eks. hvor meldingen inneholder flere filer med samme navn.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="sjekksum" type="n5mdk:sjekksum" minOccurs="0"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
@@ -188,7 +188,7 @@
             </xs:element>
             <xs:element name="referanseDokumentfil" type="n5mdk:referanseDokumentfil" minOccurs="0">
                 <xs:annotation>
-                    <xs:documentation>Dette er enten filnavn slik filen heter i meldingen eller URL som kan brukes for å hente filen. Vil normalt ikke inneholde tegn som komma, æøå etc. som gjerne er med i filnavn. Dette filnavnet vil kunne være forskjellig fra "filnavn" attributtet i ekelte tilfeller, f.eks. hvor meldingen inneholder flere filer med samme navn.</xs:documentation>
+                    <xs:documentation>Dette er enten filnavn slik filen heter i meldingen eller URL som kan brukes for å hente filen. Vil normalt ikke inneholde tegn som komma, æøå etc. som gjerne er med i filnavn. Dette filnavnet vil kunne være forskjellig fra "filnavn" attributtet i enkelte tilfeller, f.eks. hvor meldingen inneholder flere filer med samme navn.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="sjekksum" type="n5mdk:sjekksum" minOccurs="0"/>


### PR DESCRIPTION
Det stod ikke helt presist hva `referanseDokumentfil` og `filnavn` skal brukes til i `dokumentobjekt`.
La til samme kommentarene i `arkivstruktur.xsd` også