### PR TITLE
Korrigering for referanseDokumentFil

### DIFF
--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -488,7 +488,7 @@
             <xs:element name="opprettetAv" type="n5mdk:opprettetAv"/>
             <xs:element name="referanseDokumentfil" type="n5mdk:referanseDokumentfil">
                 <xs:annotation>
-                    <xs:documentation>Dette er enten filnavn slik filen heter i meldingen eller URL som kan brukes for å hente filen. Vil normalt ikke inneholde tegn som komma, æøå etc. som gjerne er med i filnavn. Dette filnavnet vil kunne være forskjellig fra "filnavn" attributtet i enkelte tilfeller, f.eks. hvor meldingen inneholder flere filer med samme navn.</xs:documentation>
+                    <xs:documentation>Dette er filnavn slik filen heter i meldingen. Vil normalt ikke inneholde tegn som komma, æøå etc. som gjerne er med i filnavn. Dette filnavnet vil kunne være forskjellig fra "filnavn" attributtet i enkelte tilfeller, f.eks. hvor meldingen inneholder flere filer med samme navn.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="sjekksum" type="n5mdk:sjekksum"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
@@ -186,9 +186,9 @@
                     <xs:documentation>Det opprinnelige filnavnet som gjerne skal brukes hvis filen lastes ned. Kan inneholde alle lovlige tegn for filnavn. Egnet også for visning.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="referanseDokumentfil" type="n5mdk:referanseDokumentfil" minOccurs="0">
+            <xs:element name="referanseDokumentfil" type="n5mdk:referanseDokumentfil">
                 <xs:annotation>
-                    <xs:documentation>Dette er enten filnavn slik filen heter i meldingen eller URL som kan brukes for å hente filen. Vil normalt ikke inneholde tegn som komma, æøå etc. som gjerne er med i filnavn. Dette filnavnet vil kunne være forskjellig fra "filnavn" attributtet i enkelte tilfeller, f.eks. hvor meldingen inneholder flere filer med samme navn.</xs:documentation>
+                    <xs:documentation>Dette er filnavn slik filen heter i meldingen. Vil normalt ikke inneholde tegn som komma, æøå etc. som gjerne er med i filnavn. Dette filnavnet vil kunne være forskjellig fra "filnavn" attributtet i enkelte tilfeller, f.eks. hvor meldingen inneholder flere filer med samme navn.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="sjekksum" type="n5mdk:sjekksum" minOccurs="0"/>


### PR DESCRIPTION
Som avtalt i møtet for Fiks Arkiv 23.05.24 korrigerer vi her nå følgende:
- Documentation korrigert til å ikke tillate URL i referanseDokumentfil. Den skal være et filnavn som er filnavnet til filen i meldingen.
- referanseDokumentfil skal være minOccurs=1