### PR TITLE
Korrigert minOccurs på felter i kvittering 

### DIFF
--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.kvittering.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.kvittering.xsd
@@ -90,9 +90,9 @@
     <xs:complexType name="dokumentbeskrivelseKvittering">
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID"/>
-            <xs:element name="opprettetDato" type="n5mdk:opprettetDato" minOccurs="0"/>
-            <xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
-            <xs:element name="dokumentnummer" type="n5mdk:dokumentnummer" minOccurs="0"/>
+            <xs:element name="opprettetDato" type="n5mdk:opprettetDato"/>
+            <xs:element name="opprettetAv" type="n5mdk:opprettetAv"/>
+            <xs:element name="dokumentnummer" type="n5mdk:dokumentnummer"/>
             <xs:element name="dokumentobjekt" type="dokumentobjektKvittering" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
@@ -100,10 +100,10 @@
     <xs:complexType name="dokumentobjektKvittering">
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID"/>
-            <xs:element name="versjonsnummer" type="n5mdk:versjonsnummer" minOccurs="0"/>
-            <xs:element name="variantformat" type="n5mdk:variantformat" minOccurs="0"/>
-            <xs:element name="opprettetDato" type="n5mdk:opprettetDato" minOccurs="0"/>
-            <xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
+            <xs:element name="versjonsnummer" type="n5mdk:versjonsnummer"/>
+            <xs:element name="variantformat" type="n5mdk:variantformat"/>
+            <xs:element name="opprettetDato" type="n5mdk:opprettetDato"/>
+            <xs:element name="opprettetAv" type="n5mdk:opprettetAv"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
@@ -160,7 +160,11 @@
             <xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
             <xs:element name="dokumentmedium" type="n5mdk:dokumentmedium" minOccurs="0"/>
             <xs:element name="tilknyttetRegistreringSom" type="n5mdk:tilknyttetRegistreringSom"/>
-            <xs:element name="dokumentnummer" type="n5mdk:dokumentnummer" minOccurs="0"/>
+            <xs:element name="dokumentnummer" type="n5mdk:dokumentnummer" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Selv om "dokumentnummer" ikke er påkrevd, så er det viktig å sette der hvor man har flere dokumentbeskrivelser. "dokumentnummer" vil være det man knytter opp mot det man får tilbake i "dokumentbeskrivelseKvittering" i kvittering-melding</xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="tilknyttetDato" type="n5mdk:tilknyttetDato" minOccurs="0"/>
             <xs:element name="tilknyttetAv" type="n5mdk:tilknyttetAv" minOccurs="0"/>
             <xs:element name="part" type="part" minOccurs="0" maxOccurs="unbounded"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.dokumentobjekt.opprett.kvittering.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.dokumentobjekt.opprett.kvittering.xsd
@@ -17,7 +17,7 @@
 
     <xs:complexType name="dokumentobjektOpprettKvittering">
         <xs:annotation>
-            <xs:documentation>Kvittering for lagt til dokumenobjekt til en dokumentbeskrivelse</xs:documentation>
+            <xs:documentation>Kvittering for lagt til dokumentobjekt til en dokumentbeskrivelse</xs:documentation>
         </xs:annotation>
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID"/>


### PR DESCRIPTION
Ref issue #210 
Det ble konkludert i møtet 23.05.24 at disse tingene bør vi fikse innenfor Fiks Arkiv V1 da det er forvirrende. 
Det som er gjort er å legge til documentation for dokumentnummer og satt minOccurs=1 på felter i kvittering da de må komme i retur, altså de må være påkrevd. Ingen struktur endringer. 

