### PR TITLE
Korrigert skjermingMinimum 

### DIFF
--- a/Schema/V1/arkivstrukturMinimum.xsd
+++ b/Schema/V1/arkivstrukturMinimum.xsd
@@ -152,10 +152,8 @@
         <xs:sequence>
             <xs:element name="tilgangsrestriksjon" type="n5mdk:tilgangsrestriksjon"/>
             <xs:element name="skjermingshjemmel" type="n5mdk:skjermingshjemmel"/>
-            <xs:element name="skjermingMetadata" type="n5mdk:skjermingMetadata" maxOccurs="unbounded"/>
-            <xs:element name="skjermingDokument" type="n5mdk:skjermingDokument" minOccurs="0"/>
-            <xs:element name="skjermingsvarighet" type="n5mdk:skjermingsvarighet" minOccurs="0"/>
             <xs:element name="skjermingOpphoererDato" type="n5mdk:skjermingOpphoererDato" minOccurs="0"/>
+            <xs:element name="skjermingOpphoererAksjon" type="n5mdk:skjermingOpphoererAksjon" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
Slik at den er lik slik det er i arkivstruktur.xsd. Bort med skjermingMetadata f.eks.
Dette ble tatt opp i issue #220 