### PR TITLE
Changes according to the latest issues

### DIFF
--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -228,10 +228,6 @@
             <xs:element name="partID" type="n5mdk:partID" minOccurs="0"/>
             <xs:element name="partNavn" type="n5mdk:partNavn"/>
             <xs:element name="partRolle" type="n5mdk:partRolle"/>
-            <xs:choice minOccurs="0">
-                <xs:element name="organisasjonID" minOccurs="0" type="organisasjonsID"/>
-                <xs:element name="personID" minOccurs="0" type="personID"/>
-            </xs:choice>
             <xs:element name="postadresse" type="n5mdk:postadresse" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="postnummer" type="n5mdk:postnummer" minOccurs="0"/>
             <xs:element name="poststed" type="n5mdk:poststed" minOccurs="0"/>
@@ -242,6 +238,10 @@
             <xs:element name="virksomhetsspesifikkeMetadata" type="xs:anyType" minOccurs="0"/>
             <xs:element name="erSkjermet" type="n5mdk:erSkjermet" minOccurs="0"/>
             <xs:element name="erPersonnavn" type="n5mdk:erPersonnavn" minOccurs="0"/>
+            <xs:choice minOccurs="0">
+                <xs:element name="organisasjonID" minOccurs="0" type="organisasjonsID"/>
+                <xs:element name="personID" minOccurs="0" type="personID"/>
+            </xs:choice>
         </xs:sequence>
     </xs:complexType>
 
@@ -409,6 +409,14 @@
             <xs:element name="administrativEnhet" type="n5mdk:administrativEnhet" minOccurs="0"/>
             <xs:element name="saksbehandler" type="n5mdk:saksbehandler" minOccurs="0"/>
             <xs:element name="avskrivning" type="avskrivning" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:choice minOccurs="0">
+                <xs:element name="organisasjonid" minOccurs="0" type="n5mdk:organisasjonid"/>
+                <xs:element name="personid" minOccurs="0" type="n5mdk:personid"/>
+            </xs:choice>
+            <xs:element name="erSkjermet" type="n5mdk:erSkjermet" minOccurs="0"/>
+            <xs:element name="erPersonnavn" type="n5mdk:erPersonnavn" minOccurs="0"/>
+            <xs:element name="forsendelsesmaate" type="n5mdk:forsendelsesmaate" minOccurs="0"/>
+            <xs:element name="deresReferanse" type="xs:string" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -205,8 +205,8 @@
                     <xs:element name="presedens" type="presedens" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="matrikkelnummer" type="matrikkelnummer" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="byggident" type="byggident" minOccurs="0" maxOccurs="unbounded"/>
-                    <xs:element name="planident" type="planident" minOccurs="0"/>
-                    <xs:element name="punkt" type="punkt" minOccurs="0"/>
+                    <xs:element name="planident" type="planident" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="punkt" type="punkt" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="adresse" type="adresse" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:sequence>
             </xs:extension>
@@ -228,6 +228,10 @@
             <xs:element name="partID" type="n5mdk:partID" minOccurs="0"/>
             <xs:element name="partNavn" type="n5mdk:partNavn"/>
             <xs:element name="partRolle" type="n5mdk:partRolle"/>
+            <xs:choice minOccurs="0">
+                <xs:element name="organisasjonID" minOccurs="0" type="organisasjonsID"/>
+                <xs:element name="personID" minOccurs="0" type="personID"/>
+            </xs:choice>
             <xs:element name="postadresse" type="n5mdk:postadresse" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="postnummer" type="n5mdk:postnummer" minOccurs="0"/>
             <xs:element name="poststed" type="n5mdk:poststed" minOccurs="0"/>
@@ -238,10 +242,6 @@
             <xs:element name="virksomhetsspesifikkeMetadata" type="xs:anyType" minOccurs="0"/>
             <xs:element name="erSkjermet" type="n5mdk:erSkjermet" minOccurs="0"/>
             <xs:element name="erPersonnavn" type="n5mdk:erPersonnavn" minOccurs="0"/>
-            <xs:choice minOccurs="0">
-                <xs:element name="organisasjonID" minOccurs="0" type="organisasjonsID"/>
-                <xs:element name="personID" minOccurs="0" type="personID"/>
-            </xs:choice>
         </xs:sequence>
     </xs:complexType>
 
@@ -399,6 +399,10 @@
                 </xs:annotation>
             </xs:element>
             <xs:element name="korrespondansepartNavn" type="n5mdk:korrespondansepartNavn"/>
+            <xs:choice minOccurs="0">
+                <xs:element name="organisasjonid" minOccurs="0" type="n5mdk:organisasjonid"/>
+                <xs:element name="personid" minOccurs="0" type="n5mdk:personid"/>
+            </xs:choice>
             <xs:element name="postadresse" type="n5mdk:postadresse" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="postnummer" type="n5mdk:postnummer" minOccurs="0"/>
             <xs:element name="poststed" type="n5mdk:poststed" minOccurs="0"/>
@@ -408,15 +412,11 @@
             <xs:element name="kontaktperson" type="n5mdk:kontaktperson" minOccurs="0"/>
             <xs:element name="administrativEnhet" type="n5mdk:administrativEnhet" minOccurs="0"/>
             <xs:element name="saksbehandler" type="n5mdk:saksbehandler" minOccurs="0"/>
-            <xs:element name="avskrivning" type="avskrivning" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:choice minOccurs="0">
-                <xs:element name="organisasjonid" minOccurs="0" type="n5mdk:organisasjonid"/>
-                <xs:element name="personid" minOccurs="0" type="n5mdk:personid"/>
-            </xs:choice>
             <xs:element name="erSkjermet" type="n5mdk:erSkjermet" minOccurs="0"/>
             <xs:element name="erPersonnavn" type="n5mdk:erPersonnavn" minOccurs="0"/>
             <xs:element name="forsendelsesmaate" type="n5mdk:forsendelsesmaate" minOccurs="0"/>
             <xs:element name="deresReferanse" type="xs:string" minOccurs="0"/>
+            <xs:element name="avskrivning" type="avskrivning" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -228,6 +228,10 @@
             <xs:element name="partID" type="n5mdk:partID" minOccurs="0"/>
             <xs:element name="partNavn" type="n5mdk:partNavn"/>
             <xs:element name="partRolle" type="n5mdk:partRolle"/>
+            <xs:choice minOccurs="0">
+                <xs:element name="organisasjonID" minOccurs="0" type="organisasjonsID"/>
+                <xs:element name="personID" minOccurs="0" type="personID"/>
+            </xs:choice>
             <xs:element name="postadresse" type="n5mdk:postadresse" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="postnummer" type="n5mdk:postnummer" minOccurs="0"/>
             <xs:element name="poststed" type="n5mdk:poststed" minOccurs="0"/>
@@ -236,6 +240,8 @@
             <xs:element name="telefonnummer" type="n5mdk:telefonnummer" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="kontaktperson" type="n5mdk:kontaktperson" minOccurs="0"/>
             <xs:element name="virksomhetsspesifikkeMetadata" type="xs:anyType" minOccurs="0"/>
+            <xs:element name="erSkjermet" type="n5mdk:erSkjermet" minOccurs="0"/>
+            <xs:element name="erPersonnavn" type="n5mdk:erPersonnavn" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -653,5 +659,25 @@
             <xs:element name="z" type="n5mdk:z" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
+
+    <xs:complexType name="organisasjonsID">
+        <xs:sequence>
+            <xs:element name="identifikator" type="xs:string"/>
+            <xs:element name="landkode" type="landkode" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="personID">
+        <xs:sequence>
+            <xs:element name="landkode" type="landkode"/>
+            <xs:element name="identifikator" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="landkode">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z]{2}"/>
+        </xs:restriction>
+    </xs:simpleType>
     
 </xs:schema>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
@@ -67,8 +67,8 @@
                     <xs:element name="presedens" type="presedens" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="matrikkelnummer" type="matrikkelnummer" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="byggident" type="byggident" minOccurs="0" maxOccurs="unbounded"/>
-                    <xs:element name="planident" type="planident" minOccurs="0"/>
-                    <xs:element name="punkt" type="punkt" minOccurs="0"/>
+                    <xs:element name="planident" type="planident" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="punkt" type="punkt" minOccurs="0" maxOccurs="unbounded"/>
                     <xs:element name="adresse" type="adresse" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:sequence>
             </xs:extension>
@@ -312,6 +312,7 @@
 
     <xs:complexType name="punkt">
         <xs:sequence>
+            <xs:element name="punktID" type="n5mdk:punktID" minOccurs="0"/>
             <xs:element name="koordinatsystem" type="n5mdk:koordinatsystem"/>
             <xs:element name="x" type="n5mdk:x"/>
             <xs:element name="y" type="n5mdk:y"/>


### PR DESCRIPTION
This could be breaking, depending on what has been implemented by archives and if we want the xsd objects to be equal across services. 

Breaking here means not in code (except if you have used `punkt` and `planident`), but in that the XML will not be valid between old version and patched version. 

There are two choices:

1. We can make this patch mostly non-breaking by putting the new (the missing) elements at the end of each object. Then the new XML would be valid against pre-patch xsd's. 
But `punkt` og `planident` will need to be changed to _unbounded_, making them lists instead of a single object. This is fine as long as none have used these.

2. We could also put the new elements that we discovered are missing in the same order as in "opprett" xsd. This would make it easier to compare across services and "cleaner". But then the new XML would not be valid against pre-patch xsd's. Same as for the other choice, the `punkt` og `planident` will need to be changed to _unbounded_, making them lists instead of a single object. This is fine as long as none have used these.

In our meeting 24.10.2024 those who were there agreed that it is ok to make these changes breaking. We want the xsd's clean and easier to read. The breaking changes can be rolled out now in a controlled manner.


 


See issue #222, #223, #225 and #226  