### PR TITLE
Changed from list of "adresse" to "adresseOppdateringer" in saksmappeOppdatering

### DIFF
--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
@@ -82,7 +82,7 @@
                     <xs:element name="byggidentOppdateringer" type="byggidentOppdateringer" minOccurs="0"/>
                     <xs:element name="planidentOppdateringer" type="planidentOppdateringer" minOccurs="0"/>
                     <xs:element name="punktOppdateringer" type="punktOppdateringer" minOccurs="0"/>
-                    <xs:element name="adresse" type="arkivmelding:adresse" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="adresseOppdateringer" type="adresseOppdateringer" minOccurs="0" />
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>


### PR DESCRIPTION
This change affects only update-messages.
It seems that we have forgot to change to the new type "adresseOppdateringer" in saksmappeOppdatering.