### PR TITLE
Endret datatypen for avskrevetAv til å bli saksbehandler objektet

### DIFF
--- a/Schema/V1/arkivstruktur.xsd
+++ b/Schema/V1/arkivstruktur.xsd
@@ -423,7 +423,7 @@
     <xs:complexType name="avskrivning">
         <xs:sequence>
             <xs:element name="avskrivningsdato" type="n5mdk:avskrivningsdato"/>
-            <xs:element name="avskrevetAv" type="n5mdk:avskrevetAv"/>
+            <xs:element name="avskrevetAv" type="n5mdk:saksbehandler"/>
             <xs:element name="avskrivningsmaate" type="n5mdk:avskrivningsmaate"/>
             <xs:element name="referanseAvskrivesAvJournalpost" type="n5mdk:referanseAvskrivesAvJournalpost"
                         minOccurs="0"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
@@ -265,7 +265,7 @@
     <xs:complexType name="avskrivning">
         <xs:sequence>
             <xs:element name="avskrivningsdato" type="n5mdk:avskrivningsdato"/>
-            <xs:element name="avskrevetAv" type="n5mdk:avskrevetAv"/>
+            <xs:element name="avskrevetAv" type="n5mdk:saksbehandler"/>
             <xs:element name="avskrivningsmaate" type="n5mdk:avskrivningsmaate"/>
             <xs:element name="referanseAvskrivesAvJournalpost" type="n5mdk:referanseTilJournalpost" minOccurs="0"/>
             <xs:element name="referanseAvskriverJournalpost" type="n5mdk:referanseTilJournalpost" minOccurs="0"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.avskrivning.opprett.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.avskrivning.opprett.xsd
@@ -39,7 +39,7 @@
         </xs:annotation>
         <xs:sequence>
             <xs:element name="avskrivningsdato" type="n5mdk:avskrivningsdato"/>
-            <xs:element name="avskrevetAv" type="n5mdk:avskrevetAv"/>
+            <xs:element name="avskrevetAv" type="n5mdk:saksbehandler"/>
             <xs:element name="avskrivningsmaate" type="n5mdk:avskrivningsmaate"/>
             <xs:element name="referanseAvskrivesAvJournalpost" type="n5mdk:referanseTilJournalpost" minOccurs="0"/>
             <xs:element name="referanseAvskriverJournalpost" type="n5mdk:referanseTilJournalpost" minOccurs="0" maxOccurs="unbounded"/>


### PR DESCRIPTION
Ref issue #231 
Vi ser at pga de feilene vi ser i issue #233 som blir "breaking" så kan og bør vi fikse dette også i samme "breaking change".

**Denne endringen er breaking for meldingstypene:**
- Opprett Arkivmelding - `no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett`
- Opprett Avskrivning -  `no.ks.fiks.arkiv.v1.arkivering.avskrivning.opprett`
- Hent meldinger som bruker avskrevetAv

Med breaking change så menes at man må gjøre kodeendring for å bygge melding og lese melding etter endring.
Det betyr også at man må endre i klient og arkivsystem samtidig, eller så vil ikke melding kunne leses av mottaker.