### PR TITLE
Opprett dokumentbeskrivelse og dokumentbeskrivelse oppdatering issue 233 og 235

### DIFF
--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
@@ -29,19 +29,23 @@
     <xs:complexType name="dokumentbeskrivelseOppdatering">
         <xs:sequence>
             <xs:element name="systemID" type="n5mdk:systemID" />
+            <xs:element name="dokumenttype" type="n5mdk:dokumenttype" minOccurs="0"/>
             <xs:element name="dokumentstatus" type="n5mdk:dokumentstatus" minOccurs="0"/>
             <xs:element name="tittel" type="n5mdk:tittel" minOccurs="0"/>
             <xs:element name="beskrivelse" type="beskrivelseOppdateringer" minOccurs="0"/>
             <xs:element name="forfatterOppdateringer" type="forfatterOppdateringer" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="opprettetDato" type="n5mdk:opprettetDato" minOccurs="0"/>
             <xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
+            <xs:element name="dokumentmedium" type="n5mdk:dokumentmedium" minOccurs="0"/>
             <xs:element name="tilknyttetRegistreringSom" type="n5mdk:tilknyttetRegistreringSom"/>
             <xs:element name="dokumentnummer" type="n5mdk:dokumentnummer" minOccurs="0"/>
             <xs:element name="tilknyttetDato" type="n5mdk:tilknyttetDato" minOccurs="0"/>
             <xs:element name="tilknyttetAv" type="n5mdk:tilknyttetAv" minOccurs="0"/>
             <xs:element name="partOppdateringer" type="partOppdateringer" minOccurs="0"/>
+            <xs:element name="merknad" type="arkivmelding:merknad" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="skjerming" type="skjermingOppdateringer" minOccurs="0"/>
             <xs:element name="gradering" type="graderingOppdateringer" minOccurs="0"/>
+            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
@@ -42,7 +42,7 @@
             <xs:element name="tilknyttetDato" type="n5mdk:tilknyttetDato" minOccurs="0"/>
             <xs:element name="tilknyttetAv" type="n5mdk:tilknyttetAv" minOccurs="0"/>
             <xs:element name="partOppdateringer" type="partOppdateringer" minOccurs="0"/>
-            <xs:element name="merknad" type="arkivmelding:merknad" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="merknadOppdateringer" type="merknadOppdateringer" minOccurs="0"/>
             <xs:element name="skjerming" type="skjermingOppdateringer" minOccurs="0"/>
             <xs:element name="gradering" type="graderingOppdateringer" minOccurs="0"/>
             <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett.xsd
@@ -172,6 +172,7 @@
             <xs:element name="skjerming" type="skjerming" minOccurs="0"/>
             <xs:element name="gradering" type="gradering" minOccurs="0"/>
             <xs:element name="dokumentobjekt" type="dokumentobjekt" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
Ref #233 og issue #235 
La begge issues inn i samme PR da de henger sammen.
Lagt inn alle felter som var mulig å opprette til oppdatering av Dokumentbeskrivelse objektet.
Har også lagt inn referanseEksternNoekkel feltet.
Usikker på merknad i oppdatering. Det er en liste med merknad objekter som kommer inn. 
Skal man bare kunne legge til, eller endre/slette merknader også? I så fall må vi utvide som på samme måte som man kan oppdatere parter. 

**Denne endringen er breaking for meldingstypene:**
- Oppdater Arkivmelding - no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater

**Gir mulighet for å legge til referanseEksternNoekkel for dokumentbeskrivelse objektet for meldingstypen:**
- Opprett Arkivmelding -  no.ks.fiks.arkiv.v1.arkivering.arkivmelding.opprett
- 
Med breaking change så menes at man må gjøre kodeendring for å bygge melding og lese melding etter endring.
Det betyr også at man må endre i klient og arkivsystem samtidig, eller så vil ikke melding kunne leses av mottaker.
