### PR TITLE
Endret til referanseTilDokumentbeskrivelse for opprett dokumentobjekt

### DIFF
--- a/Schema/V1/metadatakatalog.xsd
+++ b/Schema/V1/metadatakatalog.xsd
@@ -641,6 +641,7 @@
     <xs:sequence>
       <xs:element name="systemID" type="systemID" minOccurs="0"/>
       <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0"/>
+      <xs:element name="journalpostDokumentnummer" type="journalpostDokumentnummer" minOccurs="0"/>
     </xs:sequence>
   </xs:complexType>
 
@@ -1950,5 +1951,17 @@
       <xs:minLength value="1"/>
     </xs:restriction>
   </xs:simpleType>
+  
+  <xs:complexType name="journalpostDokumentnummer">
+    <xs:annotation>
+      <xs:documentation>M812</xs:documentation>
+      <xs:documentation>Opprettet: Fiks-arkiv</xs:documentation>
+      <xs:documentation>Identifiserer en dokumentbeskrivelse under en journalpost</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="referanseTilJournalpost" type="referanseTilJournalpost" />
+      <xs:element name="dokumentnummer" type="xs:int" />
+    </xs:sequence>
+  </xs:complexType>
 </xs:schema>
 

--- a/Schema/V1/metadatakatalog.xsd
+++ b/Schema/V1/metadatakatalog.xsd
@@ -636,10 +636,11 @@
   <xs:complexType name="referanseTilDokumentbeskrivelse">
     <xs:annotation>
       <xs:documentation>M225</xs:documentation>
-      <xs:documentation>Fiks-Arkiv: inneholder systemID som identifiserer en Dokumentbeskrivelse. Mulig å utvide senere med andre identifikatorer til en Dokumentbeskrivelse.</xs:documentation>
+      <xs:documentation>Fiks-Arkiv: inneholder systemID eller eksternNoekkel som identifiserer en Dokumentbeskrivelse.</xs:documentation>
     </xs:annotation>
     <xs:sequence>
       <xs:element name="systemID" type="systemID" minOccurs="0"/>
+      <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0"/>
     </xs:sequence>
   </xs:complexType>
 

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater.xsd
@@ -28,7 +28,7 @@
 
     <xs:complexType name="dokumentbeskrivelseOppdatering">
         <xs:sequence>
-            <xs:element name="systemID" type="n5mdk:systemID" />
+            <xs:element name="referanseTilDokumentbeskrivelse" type="n5mdk:referanseTilDokumentbeskrivelse" />
             <xs:element name="dokumentstatus" type="n5mdk:dokumentstatus" minOccurs="0"/>
             <xs:element name="tittel" type="n5mdk:tittel" minOccurs="0"/>
             <xs:element name="beskrivelse" type="beskrivelseOppdateringer" minOccurs="0"/>

--- a/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.dokumentobjekt.opprett.xsd
+++ b/Schema/V1/no.ks.fiks.arkiv.v1.arkivering.dokumentobjekt.opprett.xsd
@@ -19,14 +19,10 @@
 
     <xs:complexType name="dokumentobjektOpprett">
         <xs:annotation>
-            <xs:documentation>Legg til et dokumenobjekt til en dokumentbeskrivelse basert på dokumentbeskrivelseID</xs:documentation>
+            <xs:documentation>Legg til et dokumenobjekt til en dokumentbeskrivelse basert på referanseTilDokumentbeskrivelse</xs:documentation>
         </xs:annotation>
         <xs:sequence>
-            <xs:element name="dokumentbeskrivelseID" type="n5mdk:systemID" >
-                <xs:annotation>
-                    <xs:documentation>Dette er systemID til dokumentbeskrivelsen som dokumentobjekt skal legges til</xs:documentation>
-                </xs:annotation>
-            </xs:element>
+            <xs:element name="referanseTilDokumentbeskrivelse" type="n5mdk:referanseTilDokumentbeskrivelse" />
             <xs:element name="dokumentobjekt" type="arkivmelding:dokumentobjekt" />
         </xs:sequence>
     </xs:complexType>


### PR DESCRIPTION
Endret id for opprette dokumentobjekt til referanseTilDokumentbeskrivelse og lagt til eksternNoekkel i den.
Ref issue #239 

**Denne endringen er breaking for meldingstypene:**
- Oppdater Arkivmelding - `no.ks.fiks.arkiv.v1.arkivering.arkivmelding.oppdater`
- Opprett Dokumentobjekt - ` no.ks.fiks.arkiv.v1.arkivering.dokumentobjekt.opprett`

Med breaking change så menes at man må gjøre kodeendring for å bygge melding og lese melding etter endring.
Det betyr også at man må endre i klient og arkivsystem samtidig, eller så vil ikke melding kunne leses av mottaker.