### PR TITLE
V2: lagt til referandeEksternNoekkel til dokumentbeskrivelseKvittering

### DIFF
--- a/Schema/V2/no.ks.fiks.arkiv.v2.arkivering.arkivmelding.opprett.kvittering.xsd
+++ b/Schema/V2/no.ks.fiks.arkiv.v2.arkivering.arkivmelding.opprett.kvittering.xsd
@@ -94,6 +94,7 @@
             <xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
             <xs:element name="dokumentnummer" type="n5mdk:dokumentnummer" minOccurs="0"/>
             <xs:element name="dokumentobjekt" type="dokumentobjektKvittering" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="referanseEksternNoekkel" type="n5mdk:eksternNoekkel" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
Ref issue #278 
Added `referanseEksternNoekkel` to `dokumentbeskrivelseKvittering` object in opprett kvittering message.
This change is only added in V2